### PR TITLE
Config not to create unnecessary test-files when doing rails g

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,15 @@ module RerPro
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.time_zone = 'Asia/Tokyo'
+    
+    # 以下のテストは少なくともフェーズ１では不要のようなので、余計なファイルを作らないよう設定。
+    config.generators do |g|
+      g.test_framework :rspec,
+        view_specs: false, # ビュースペックは、「信頼性の高いビューのテストを作ることは非常に面倒」とのこと。
+        helper_specs: false, # Rspecに慣れて、余力が出てきたらtrueにしてもよいとのこと。
+        routing_specs: false # ルーティングは、テストが要らないくらいシンプルにすべし、とのこと。
+    end
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
昨日話した、「rails g した際に余計なテストファイルを作らないようにする設定」を追記しました。

下記URLの2の「 ジェネレータ」の内容です。
https://leanpub.com/everydayrailsrspec-jp/read_sample