### PR TITLE
Add lead model test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
+  gem 'shoulda-matchers', '~> 4.0' # 手書きだと長くて複雑でエラーが起きやすいRailsのテストを、1行で書けるようになる。(RspecとMinitestに対応)
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -279,6 +281,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers (~> 4.0)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Lead, type: :model do
-#  pending "add some examples to (or delete) #{__FILE__}"
   if Company.find_by(name: "サンプル企業").blank?
     Company.create!(
       name: "サンプル企業",
@@ -34,31 +33,37 @@ RSpec.describe Lead, type: :model do
       customer_name: "お客様A",
       room_name: "物件A",
       room_num:	"部屋A",
-    #  template: "",
+    #  template: false,
     #  template_name: "",
     #  memo: "",
     #  status: "進捗中"
-    #  notice_created: 新規申込時通知
-    #  notice_change_limit: 期限変更時通知
+    #  notice_created: true
+    #  notice_change_limit: false
       scheduled_resident_date: (Date.current + 21).to_s,
       scheduled_payment_date: (Date.current + 14).to_s,
-    #  scheduled_contract_date: 契約予定日
-    #  steps_rate: 進捗率
+    #  scheduled_contract_date: ""
+    #  steps_rate: 0
     )
     expect(lead).to be_valid
   end
   
   presense_columns = [:created_date, :customer_name, :room_name, :room_num, :scheduled_resident_date, :scheduled_payment_date]
-  presense_columns. each do |column_name|
-    describe "の#{column_name}がnilだと無効。" do
-      it { should validate_presence_of(column_name) }
+  presense_columns. each do |presense_column|
+    describe "の#{presense_column}がnilだと無効。" do
+      it { should validate_presence_of(presense_column) }
     end
   end
 
-  
-  # boolean型のカラムにtrueかfalseを許可し、nilは許可しないテストが未実装。
-  # gem "shoulda-matchers" を導入して、allow_valueを使うのが簡単そう。
+  # boolean型のカラムにtrueかfalseを許可し、nilは許可しない。
   # 参考サイト：https://note.com/ishibai/n/n2c27ff7288e3
+  boolean_columns = [:notice_created, :notice_change_limit, :template]
+  boolean_columns. each do |boolean_column|
+    describe "の#{boolean_column}にtrueかfalseを許可。nilは無効。" do
+      it { is_expected.to allow_value(true).for(boolean_column) }
+      it { is_expected.to allow_value(false).for(boolean_column) }
+      it { is_expected.not_to allow_value(nil).for(boolean_column) }
+    end
+  end
 
   it "はtemplateがtrueのときにtemplate_nameがnilだと無効。" do
     lead = Lead.new(template: true, template_name: nil)

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -48,41 +48,13 @@ RSpec.describe Lead, type: :model do
     expect(lead).to be_valid
   end
   
-  it "はcreated_dateがnilだと無効。" do
-    lead = Lead.new(created_date: nil)
-    lead.valid?
-    expect(lead.errors[:created_date]).to include("を入力してください")
+  presense_columns = [:created_date, :customer_name, :room_name, :room_num, :scheduled_resident_date, :scheduled_payment_date]
+  presense_columns. each do |column_name|
+    describe "の#{column_name}がnilだと無効。" do
+      it { should validate_presence_of(column_name) }
+    end
   end
 
-  it "はcustomer_nameがnilだと無効。" do
-    lead = Lead.new(customer_name: nil)
-    lead.valid?
-    expect(lead.errors[:customer_name]).to include("を入力してください")
-  end
-
-  it "はroom_nameがnilだと無効。" do
-    lead = Lead.new(room_name: nil)
-    lead.valid?
-    expect(lead.errors[:room_name]).to include("を入力してください")
-  end
-
-  it "はroom_numがnilだと無効。" do
-    lead = Lead.new(room_num: nil)
-    lead.valid?
-    expect(lead.errors[:room_num]).to include("を入力してください")
-  end
-
-  it "はscheduled_resident_dateがnilだと無効。" do
-    lead = Lead.new(scheduled_resident_date: nil)
-    lead.valid?
-    expect(lead.errors[:scheduled_resident_date]).to include("を入力してください")
-  end
-
-  it "はscheduled_payment_dateがnilだと無効。" do
-    lead = Lead.new(scheduled_payment_date: nil)
-    lead.valid?
-    expect(lead.errors[:scheduled_payment_date]).to include("を入力してください")
-  end
   
   # boolean型のカラムにtrueかfalseを許可し、nilは許可しないテストが未実装。
   # gem "shoulda-matchers" を導入して、allow_valueを使うのが簡単そう。

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,3 +62,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+# gem 'shoulda-matchers'の導入に必要
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
変更点
１．gem 'shoulda-matchers'を追加。（boolean型のテストのために必要）
２．Leadモデルにboolean型のテストを追加。
　　参考サイト：https://note.com/ishibai/n/n2c27ff7288e3

＜備考＞
shoulda-matchersって何？1分で説明しろやな人はこちら↓
https://qiita.com/mightysosuke/items/62967c9a7d24f59344f9

導入方法：公式ドキュメント↓
https://github.com/thoughtbot/shoulda-matchers