### PR TITLE
Feature/devise user create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :authenticate_user!
 
   # ユーザーIDを取得し識別
   def set_user
@@ -28,9 +27,9 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
-  # 管理者かどうか識別し管理者以外ならtopに戻しflash表示
+  # ログインユーザーを管理者かどうか識別し管理者以外ならtopに戻しflash表示
   def current_user_admin?
-    unless current_user.admin? || user_signed_in?
+    if user_signed_in? && current_user.admin?
       redirect_to root
       flash[:danger] = "アクセスが無効です。"
     end
@@ -38,8 +37,8 @@ class ApplicationController < ActionController::Base
   protected
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :login_id, :superior, :admin, :superior_id, :company_id])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :login_id, :status, :superior, :admin, :superior_id, :company_id])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:login_id])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :superior, :superior_id, :email, :notified_num, :password, :password_confirmation, :current_password])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :superior, :status, :superior_id, :email, :notified_num, :password, :password_confirmation, :current_password])
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,10 +28,18 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
+  # 管理者かどうか識別し管理者以外ならtopに戻しflash表示
+  def current_user_admin?
+    unless current_user.admin? || user_signed_in?
+      redirect_to root
+      flash[:danger] = "アクセスが無効です。"
+    end
+  end
   protected
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :login_id, :superior, :admin, :superior_id, :company_id])
       devise_parameter_sanitizer.permit(:sign_in, keys: [:login_id])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :superior, :superior_id, :email, :notified_num, :password, :password_confirmation, :current_password])
     end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -25,15 +25,11 @@ class CompaniesController < ApplicationController
   # POST /companies.json
   def create
     @company = Company.new(company_params)
-
-    respond_to do |format|
-      if @company.save
-        format.html { redirect_to @company, notice: 'Company was successfully created.' }
-        format.json { render :show, status: :created, location: @company }
-      else
-        format.html { render :new }
-        format.json { render json: @company.errors, status: :unprocessable_entity }
-      end
+    if @company.save
+      redirect_to company_new_user_registration_path(company_id: @company)
+      flash[:success] = "企業を登録しました。続いて管理者を作成してください。"
+    else
+      render :new
     end
   end
 
@@ -64,11 +60,11 @@ class CompaniesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_company
-      @company = Company.find(params[:id])
+      @company = Company.find(params[:id]).id
     end
 
     # Only allow a list of trusted parameters through.
     def company_params
-      params.require(:company).permit(:name, :admin, :status)
+      params.require(:company).permit(:name, :status)
     end
 end

--- a/app/controllers/users/application_controller.rb
+++ b/app/controllers/users/application_controller.rb
@@ -1,0 +1,3 @@
+class Users::ApplicationController < ApplicationController
+  before_action :authenticate_user!
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,20 +4,21 @@ class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :require_no_authentication, only: [:cancel]
   prepend_before_action :authenticate_scope!, only: [:update, :destroy]
   prepend_before_action :set_minimum_password_length, only: [:new, :edit]
+  before_action :current_user_admin?, only: %i(new create cancel)
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
   before_action :set_user, only: [:edit, :update]
   before_action :set_members, only: [:edit, :update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    super
+  end
 
   # POST /resource
-  # def create 
-  #   super
-  # end
+  def create
+    super
+  end
 
   # GET /resource/edit
   def edit
@@ -80,13 +81,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :superior, :superior_id, :email, :notified_num, :password, :password_confirmation, :current_password])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   end
 
   # The path used after sign up.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,14 +11,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :set_members, only: [:edit, :update]
 
   # GET /resource/sign_up
-  def new
-    super
-  end
+  # def new
+  #   super
+  # end
 
   # POST /resource
-  def create
-    super
-  end
+  # def create
+  #   super
+  # end
 
   # GET /resource/edit
   def edit
@@ -118,9 +118,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    super(resource)
+  end
 
   def sign_up(resource_name, resource)
     if !current_user_is_admin?
@@ -150,7 +150,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    super(resource)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,23 @@
-class UsersController < ApplicationController
+class UsersController < Users::ApplicationController
   before_action :set_user, only: %i(show edit destroy)
   before_action :set_members, only: %i(index edit)
+  before_action :set_company_id, only: :new
 
   def index
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    if @user.create!(user_params)
+      flash[:success] = "登録に成功しました"
+      log_in @user
+      redirect_to user_url
+    else
+      flash[:danger] = "登録に失敗しました"
+    end
   end
 
   def show
@@ -16,4 +31,10 @@ class UsersController < ApplicationController
     @user.destroy ? flash[:success] : flash[:danger]
     redirect_to users_url
   end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :login_id, :superior, :email, :password, :password_confirmation, :company_id, :superior_id)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < Users::ApplicationController
   before_action :set_user, only: %i(show edit destroy)
   before_action :set_members, only: %i(index edit)
-  before_action :set_company_id, only: :new
 
   def index
   end
@@ -11,12 +10,13 @@ class UsersController < Users::ApplicationController
   end
 
   def create
-    if @user.create!(user_params)
+    @user = User.new(user_params)
+    if @user.save
       flash[:success] = "登録に成功しました"
-      log_in @user
-      redirect_to user_url
+      redirect_to users_url
     else
       flash[:danger] = "登録に失敗しました"
+      render :new
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :login_id, uniqueness: true, length: { in: 2..20 }
   validates :superior, inclusion: { in: [true, false] }
   validates :admin, inclusion: { in: [true, false] }
-  validates :superior_id, presence: true
+  validates :superior_id, presence: true, if: :start_up_create_user?
   validates :lead_count, numericality: { greater_than_or_equal_to: 0 }
   validates :lead_count_delay, numericality: { greater_than_or_equal_to: 0 }
   validates :notified_num, numericality: { greater_than_or_equal_to: 0 }, presence: true
@@ -28,6 +28,11 @@ class User < ApplicationRecord
            User.find(superior_id).status == "active"
       errors.add(:superior_id, "に無効な人物が入力されています。")
     end
+  end
+
+  # 所属している企業内に他のユーザーが存在するか検証
+  def start_up_create_user?
+    User.where(company_id: self.company_id) == nil?
   end
 
   # 同じ会社内の全ユーザー一覧

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,14 @@ class User < ApplicationRecord
                  retirement: 2
                }
 
-  validate :active_superior_in_the_same_company, on: :update
+  validate :active_superior_in_the_same_company, on: :update, if: :start_up_create_user?
 
   validates :name, length: { in: 3..50 }
   validates :login_id, uniqueness: true, length: { in: 2..20 }
   validates :superior, inclusion: { in: [true, false] }
   validates :admin, inclusion: { in: [true, false] }
-  validates :superior_id, presence: true, if: :start_up_create_user?
+  validates :superior_id, presence: true, if: :start_up_create_user?,
+                                          unless: -> { admin? }
   validates :lead_count, numericality: { greater_than_or_equal_to: 0 }
   validates :lead_count_delay, numericality: { greater_than_or_equal_to: 0 }
   validates :notified_num, numericality: { greater_than_or_equal_to: 0 }, presence: true

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: company, local: true) do |form| %>
   <% if company.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(company.errors.count, "error") %> prohibited this company from being saved:</h2>
+      <h2><%= pluralize(company.errors.count, "エラー") %></h2>
 
       <ul>
       <% company.errors.full_messages.each do |message| %>
@@ -16,15 +16,8 @@
     <%= form.text_field :name %>
   </div>
 
-  <div class="field">
-    <%= form.label :admin %>
-    <%= form.check_box :admin %>
-  </div>
-
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.number_field :status %>
-  </div>
+    <%= form.hidden_field :admin, value: false %>
+    <%= form.hidden_field :status, value: "active" %>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Company</h1>
+<h1>会社新規登録</h1>
 
 <%= render 'form', company: @company %>
 
-<%= link_to 'Back', companies_path %>
+<%= link_to '戻る', companies_path %>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -6,14 +6,11 @@
 </p>
 
 <p>
-  <strong>Admin:</strong>
-  <%= @company.admin %>
-</p>
-
-<p>
   <strong>Status:</strong>
   <%= @company.status_i18n %>
 </p>
+
+<p><%= link_to "管理者登録", new_user_registration_path %></p>
 
 <%= link_to 'Edit', edit_company_path(@company) %> |
 <%= link_to 'Back', companies_path %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,6 +22,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :status %><br/>
+    <%= f.select :status, User.statuses.keys.map { |k| [I18n.t("enums.user.status.#{k}"), k]}, autofocus: true, autocomplete: "status" %>
+  </div>
+
+  <div class="field">
     <%= f.label :superior_id %><br/>
     <%= f.select :superior_id, superior_list(@users, @user), autofocus: true, autocomplete: "superior_id" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,7 +34,7 @@
     <%= f.submit t('.sign_up') %>
   </div>
   <%= f.hidden_field :admin, value: true %>
-  <%= f.hidden_field :superior, value: false %>
+  <%= f.hidden_field :superior, value: true %>
   <%= f.hidden_field :company_id, value: params[:company_id] %>
   <%= f.hidden_field :superior_id, value: "" %>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<%# 一般User作成form %>
 <h2><%= t('.sign_up') %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
@@ -26,7 +27,7 @@
     <%= f.label :password %>
     <% if @minimum_password_length %>
     <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %><br />
+    <% end %><br/>
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), root_path(resource_name) %><br />
+  <%= link_to t(".sign_in"), root_path(resource_name) %><br/>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  <%= link_to "新しく企業を登録する", new_company_path %><br/>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br/>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br/>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br/>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br/>
   <% end %>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if obj.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      入力した内容に<%= obj.errors.count %>件のエラーがあります。
+    </div>
+    <ul>
+    <% obj.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,8 @@
-<%# 一般ユーザー作成form %>
+<h2>ユーザー新規登録</h2>
 
 <%= form_with(model: @user, url: users_path, local: true) do |f| %>
-  <%= render "devise/shared/error_messages", resource: @user %>
+  <%= render partial: 'shared/error_messages' ,locals: {obj: @user} %>
+
   <div class="field">
     <%= f.label :name %><br/>
     <%= f.text_field :name, autofocus: true, autocomplete: "name" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
-<h2>管理者アカウント作成</h2>
+<%# 一般ユーザー作成form %>
 
-<%= form_for(resource, as: resource_name, url: company_user_registration_path(company_id: params[:company_id])) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_with(model: @user, url: users_path, local: true) do |f| %>
+  <%= render "devise/shared/error_messages", resource: @user %>
   <div class="field">
     <%= f.label :name %><br/>
     <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
@@ -10,6 +10,11 @@
   <div class="field">
     <%= f.label :login_id %><br/>
     <%= f.text_field :login_id, autofocus: true, autocomplete: "login_id" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :superior %><br/>
+    <%= f.check_box :superior, autofocus: true, autocomplete: "superior" %>
   </div>
 
   <div class="field">
@@ -31,12 +36,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit t('.sign_up') %>
+    <%= f.submit "登録" %>
   </div>
-  <%= f.hidden_field :admin, value: true %>
-  <%= f.hidden_field :superior, value: false %>
-  <%= f.hidden_field :company_id, value: params[:company_id] %>
-  <%= f.hidden_field :superior_id, value: "" %>
+  <%= f.hidden_field :company_id, autofocus: true, value: current_user.company_id %>
+  <%= f.hidden_field :superior_id, autofocus: true, value: current_user.superior_id %>
 <% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,8 @@
 <%= current_user.name %>
 
 <%= link_to "ユーザー一覧", users_path %>
+
+<%= link_to "ユーザー新規登録", new_user_registration_path %>
 <%= link_to "編集", edit_other_user_registration_path(current_user) %>
 
 <%= link_to "案件一覧", leads_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
 
 <%= link_to "ユーザー一覧", users_path %>
 
-<%= link_to "ユーザー新規登録", new_user_registration_path %>
+<%= link_to "ユーザー新規登録", new_user_path %>
 <%= link_to "編集", edit_other_user_registration_path(current_user) %>
 
 <%= link_to "案件一覧", leads_path %>

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -9,6 +9,8 @@ ja:
     attributes:
       company:
         id: ID
+        name: 会社名
+        status: ステータス
       user:
         id: ID
         status: ステータス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,21 @@
 Rails.application.routes.draw do
 
-  resources :companies
+  resources :companies do
+    devise_scope :user do
+      get 'users/sign_up' => 'users/registrations#new', as: :new_user_registration
+      post 'users' => 'users/registrations#create', as: :user_registration
+    end
+  end
   
   devise_scope :user do
     root :to => "devise/sessions#new"
     post 'login' => 'devise/sessions#create', as: :user_session
     delete 'logout' => 'devise/sessions#destroy', as: :destroy_user_session
-    get 'users/sign_up' => 'users/registrations#new', as: :new_user_registration
-    post 'users' => 'users/registrations#create', as: :user_registration
   end
   devise_for :users, skip: [:sessions, :registrations], controllers: {
     registrations: "users/registrations"
   }
-  resources :users, :only => [:index, :show, :destroy]
+  resources :users, :only => [:index, :new, :create, :show, :destroy]
   devise_scope :user do
     get 'users/:id/edit' => 'users/registrations#edit', as: :edit_other_user_registration
     match 'users/:id', to: 'users/registrations#update', via: [:patch, :put], as: :other_user_registration

--- a/db/migrate/20200819030301_devise_create_users.rb
+++ b/db/migrate/20200819030301_devise_create_users.rb
@@ -7,7 +7,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :login_id, null: false
       t.boolean :superior, default: false
       t.boolean :admin, default: false
-      t.integer :superior_id, null: false
+      t.integer :superior_id
       t.integer :lead_count, default: 0
       t.integer :lead_count_delay, default: 0
       t.integer :notified_num, default: 3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 2020_08_30_064219) do
     t.string "login_id", null: false
     t.boolean "superior", default: false
     t.boolean "admin", default: false
-    t.integer "superior_id", null: false
+    t.integer "superior_id"
     t.integer "lead_count", default: 0
     t.integer "lead_count_delay", default: 0
     t.integer "notified_num", default: 3


### PR DESCRIPTION
やったこと

・企業内ユーザー新規登録ロジック作成
　　管理者からユーザーの登録をした際の挙動を作成

・deviseのauthenticate_userを切り出した
　　今後before_action :authenticate_user!を適用させたい場合は
　　controllerの継承元クラスをUsers::ApplicationControllerに変更する仕様にしました。
　　参考: https://qiita.com/ryuuuuuuuuuu/items/bf7e2ea18ef29254b3dd

・管理者sign_upと一般ユーザーsign_upを切り出す
　　deviseの制御が難しい挙動と混ざるので分けました。

・汎用性の高いエラーメッセージテンプレート作成
　　deviseのテンプレートしかなかったので作成。
　　users#new.html.erbのテンプレートを真似してもできますが
　　一応使い方の参考は自分のメモですが参考に残しておきます。
　　参考: https://qiita.com/tr76aquarius/private/50ae578cb8b6dcfd6033
　
・企業新規作成&管理者とそれ以外のUser作成ロジック,マイグレーションファイル修正
　　フェーズ2に回す予定でしたがusers#create,users/registrations#createを作成時点で完成してしまったので作成。
　　マイグレーションについては該当行にコメント残しておきます。

　以上、ファイル量が多くなりましたがレビューよろしくお願いします。

