### PR TITLE
ルーティングにshallow: trueを導入

### DIFF
--- a/app/assets/javascripts/steps/step_statuses.coffee
+++ b/app/assets/javascripts/steps/step_statuses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/steps/step_statuses.scss
+++ b/app/assets/stylesheets/steps/step_statuses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the steps/step_statuses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/steps/step_statuses_controller.rb
+++ b/app/controllers/steps/step_statuses_controller.rb
@@ -1,0 +1,16 @@
+class Steps::StepStatusesController < StepsController
+  # オブジェクトの準備
+  before_action :set_step
+  
+  def edit
+  end
+  
+  def complete
+  end
+  
+  def restart
+  end
+  
+  def cancel
+  end
+end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,7 +1,7 @@
 class StepsController < Leads::ApplicationController
   # オブジェクトの準備
   before_action :set_step, only: %i(show edit update destroy)
-  before_action :set_lead_and_user_by_lead_id
+  before_action :set_lead_and_user_by_lead_id, only: %i(index new create)
   # フィルター（アクセス権限）
   before_action :correct_user, except: %i(index show)
   # 後処理
@@ -34,7 +34,7 @@ class StepsController < Leads::ApplicationController
     @step = @lead.steps.new(step_params)
     respond_to do |format|
       if save_and_errors_of(@step).blank?
-        format.html { redirect_to [@lead, @step], notice: 'Step was successfully created.' }
+        format.html { redirect_to @step, notice: 'Step was successfully created.' }
         format.json { render :show, status: :created, location: @step }
       else
         format.html { render :new }
@@ -48,7 +48,7 @@ class StepsController < Leads::ApplicationController
   def update
     respond_to do |format|
       if update_and_errors_of(@step).blank?
-        format.html { redirect_to [@lead, @step], notice: 'Step was successfully updated.' }
+        format.html { redirect_to @step, notice: 'Step was successfully updated.' }
         format.json { render :show, status: :ok, location: @step }
       else
         format.html { render :edit }
@@ -63,7 +63,7 @@ class StepsController < Leads::ApplicationController
     @step.destroy
     update_steps_rate(@lead)
     respond_to do |format|
-      format.html { redirect_to lead_steps_url, notice: 'Step was successfully destroyed.' }
+      format.html { redirect_to lead_steps_url(@lead), notice: 'Step was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
@@ -72,6 +72,8 @@ class StepsController < Leads::ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_step
       @step = Step.find(params[:id])
+      @lead = Lead.find(@step.lead_id)
+      @user = User.find(@lead.user_id)
     end
     
     # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,6 @@
-class TasksController < StepsController
+class TasksController < Leads::ApplicationController
   before_action :set_task, only: %i(show edit update destroy)
-  #before_action :set_lead_and_user_by_lead_id
-  before_action :set_step, only: %i(show index new create edit update)
+  before_action :set_step, only: %i(index new create)
 
   def index
     @tasks = Task.all
@@ -21,8 +20,8 @@ class TasksController < StepsController
     @task = Task.new(task_params)
     respond_to do |format|
       if @task.save && update_completed_tasks_rate(@step)
-        format.html { redirect_to lead_step_tasks_path(params[:lead_id],params[:step_id]), notice: 'Task was successfully created.' }
-        format.json { render :show, status: :created, location: lead_step_tasks_path(params[:lead_id],params[:step_id]) }
+        format.html { redirect_to step_tasks_path(@step), notice: 'Task was successfully created.' }
+        format.json { render :show, status: :created, location: step_tasks_path(@step) }
       else
         format.html { render :new }
         format.json { render json: @task.errors, status: :unprocessable_entity }
@@ -34,8 +33,8 @@ class TasksController < StepsController
   def update
     respond_to do |format|
       if @task.update(task_params) && update_completed_tasks_rate(@step)
-        format.html { redirect_to lead_step_tasks_path(params[:lead_id],params[:step_id]), notice: 'Task was successfully updated.' }
-        format.json { render :show, status: :ok, location: lead_step_tasks_path(params[:lead_id],params[:step_id]) }
+        format.html { redirect_to step_tasks_path(@step), notice: 'Task was successfully updated.' }
+        format.json { render :show, status: :ok, location: step_tasks_path(@step) }
       else
         format.html { render :edit }
         format.json { render json: @task.errors, status: :unprocessable_entity }
@@ -47,7 +46,7 @@ class TasksController < StepsController
     @task.destroy
     update_completed_tasks_rate(@step)
     respond_to do |format|
-      format.html { redirect_to lead_step_tasks_path(params[:lead_id],params[:step_id]), notice: 'Task was successfully destroyed.' }
+      format.html { redirect_to step_tasks_path(@step), notice: 'Task was successfully destroyed.' }
       format.json { head :no_content }
     end
   end
@@ -55,6 +54,7 @@ class TasksController < StepsController
   private
     def set_task
       @task = Task.find(params[:id])
+      @step = Step.find(@task.step_id)
     end
  
     def set_step

--- a/app/helpers/steps/step_statuses_helper.rb
+++ b/app/helpers/steps/step_statuses_helper.rb
@@ -1,0 +1,2 @@
+module Steps::StepStatusesHelper
+end

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model:[@lead, step], local: true) do |form| %>
+<%= form_with(model: [lead, step], local: true) do |form| %>
   <% if step.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(step.errors.count, "error") %> prohibited this step from being saved:</h2>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing Step</h1>
 
-<%= render 'form', step: @step %>
+<%= render 'form', lead: nil, step: @step %>
 
-<%= link_to 'Show', [@lead, @step] %> |
-<%= link_to 'Back', lead_steps_path %>
+<%= link_to 'Show', @step %> |
+<%= link_to 'Back', lead_steps_path(@lead) %>

--- a/app/views/steps/index.html.erb
+++ b/app/views/steps/index.html.erb
@@ -28,9 +28,9 @@
         <td><%= step.scheduled_complete_date %></td>
         <td><%= step.completed_date %></td>
         <td><%= step.completed_tasks_rate %></td>
-        <td><%= link_to 'Show', lead_step_path(@lead, step) %></td>
-        <td><%= link_to 'Edit', edit_lead_step_path(@lead, step) %></td>
-        <td><%= link_to 'Destroy', lead_step_path(@lead, step), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', step_path(step) %></td>
+        <td><%= link_to 'Edit', edit_step_path(step) %></td>
+        <td><%= link_to 'Destroy', step_path(step), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New Step</h1>
 
-<%= render 'form', step: @step %>
+<%= render 'form', lead: @lead, step: @step %>
 
 <%= link_to 'Back', lead_steps_path %>

--- a/app/views/steps/show.html.erb
+++ b/app/views/steps/show.html.erb
@@ -40,5 +40,6 @@
   <%= @step.completed_tasks_rate %>
 </p>
 
-<%= link_to 'Edit', edit_lead_step_path(@lead, @step) %> |
+<%= link_to 'Task-index', step_tasks_path(@step) %> |
+<%= link_to 'Edit', edit_step_path(@step) %> |
 <%= link_to 'Back', lead_steps_path(@lead) %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -2,7 +2,7 @@
 <% provide(:class_text, 'task--edit') %>
 <% provide(:button_text, '更新') %>
 <h1>タスク編集</h1>
-<%= form_with(model: @task, url: lead_step_task_path(lead_id: @lead, step_id: @step), method: :patch, local: true) do |f| %>
+<%= form_with(model: @task, url: task_path(@task), method: :patch, local: true) do |f| %>
 
   <%= render partial: 'shared/error_messages' ,locals: {obj: @task} %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,9 +11,9 @@
         <% @tasks.each do |task| %>
           <tr>
             <td><input type="checkbox" name="Delete" id="delete_checkbox" /></td>
-            <td><%= link_to "#{task.name}", lead_step_task_path(@lead, @step, task) %></td>
+            <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.scheduled_complete_date %></td>
-            <td><%= link_to '削除', lead_step_task_path(@lead, @step ,task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
+            <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>
         <% end %>
       </tbody>
@@ -21,7 +21,7 @@
 
     <br>
 
-    <%= link_to '新規作成', new_lead_step_task_path(@lead,@step) %>
+    <%= link_to '新規作成', new_step_task_path(@step) %>
 
   </body>
 </html>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -2,7 +2,7 @@
 <% provide(:class_text, 'task--new') %>
 <% provide(:button_text, '作成') %>
 <h1>タスク作成</h1>
-<%= form_with(model: @task, url: lead_step_tasks_path(lead_id: @lead, step_id: @step), method: :post, local: true) do |f| %>
+<%= form_with(model: @task, url: step_tasks_path(@step), method: :post, local: true) do |f| %>
 
   <%= render partial: 'shared/error_messages' ,locals: {obj: @task} %>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -32,4 +32,4 @@
   <strong>Canceled_date</strong>
   <%= @task.canceled_date %>
 </p>
-<%= link_to '編集', edit_lead_step_task_path(@lead, @step, @task) %>
+<%= link_to '編集', edit_task_path(@task) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,12 +22,18 @@ Rails.application.routes.draw do
     match 'users/:id', to: 'users/registrations#update', via: [:patch, :put], as: :other_user_registration
   end
   
-  resources :leads do
+  resources :leads, shallow: true do
     member do
       get 'edit_user_id'
       patch 'update_user_id'
     end
     resources :steps do
+      member do
+        get 'edit_status' => 'steps/step_statuses#edit', as: :edit_statuses_of
+        patch 'complete' => 'steps/step_statuses#complete', as: :complete
+        patch 'restart' => 'steps/step_statuses#restart', as: :restart
+        patch 'cancel' => 'steps/step_statuses#cancel', as: :cancel
+      end
       resources :tasks
     end
 

--- a/spec/requests/steps/step_statuses_request_spec.rb
+++ b/spec/requests/steps/step_statuses_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Steps::StepStatuses", type: :request do
+
+end


### PR DESCRIPTION
2点変更しました。

１．ルーティングにshallow: trueを導入
＜背景＞Stepの進退機能を実装するためにアクションを追加するにあたり、ルーティングを見直していたら、Railsガイドで2回以上のネストが推奨されないことを知りました。
Railsガイド：https://railsguides.jp/routing.html#%E3%83%8D%E3%82%B9%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0%E5%9B%9E%E6%95%B0%E3%81%AE%E4%B8%8A%E9%99%90

＜変更内容＞
そこで、ルーティングにshallow: trueを導入してみました。
上記Railsガイドにも使い方が載っていましたが、より実践的な解説があったので下記もご参照ください。
https://qiita.com/youmts/items/7fd67ddb05ba3593c4d3

簡単に言うと、urlで指定するidが末尾のひとつで済みます。
（show, edit, update, destroyではそのモデルのid）
（index, new, createではそのモデルの親のid）
パスもURLも短くなります。

＜注意点＞
例えば、
@step = Step.find(params[:step_id])
で取得していたところを、
@step = Step.find(@task.step_id)
で取得することになります。

Company、Userまわりには影響ありませんが、Taskまわりはもろに影響を受けるので、私の方で最低限の修正を加えました。現在developにマージされている分は、CRUDする上でエラーが出なくなったことを確認していますが、現在実装されている箇所でエラーが出るかもしれません・・・そこはご容赦及びご協力いただけますと幸いです。
以上、今の時点ならまだ修正が効くと思い、提案する次第です。ご確認ください。

----------------------------------------------------------------------------------
２．Stepを進退させるためのアクションを追加しました。
ルーティングやコントローラのフォルダ構成をご確認いただき、もしご意見ございましたらいただけると幸いです。
（本当はこちらがメインの変更だったのですが・・・笑）