### PR TITLE
Add canceled list

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,3 +1,0 @@
-.modal-dialog-center {
-  padding-top: 10%;
-}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,0 +1,3 @@
+.modal-dialog-center {
+  padding-top: 10%;
+}

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -21,6 +21,10 @@
   width: 30%;
 }
 
+.modal-dialog-center {
+  padding-top: 10%;
+}
+
 .modal-header {
   margin-left: 0;
   margin-right: auto;

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -12,3 +12,16 @@
   margin-top: 10px;
 }
 
+.label-revive-from-canceled-list {
+  margin-top: 5px;
+}
+
+.btn-revive-from-canceled-list {
+  margin: 15px 0;
+  width: 30%;
+}
+
+.modal-header {
+  margin-left: 0;
+  margin-right: auto;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,12 +1,13 @@
 class TasksController < Leads::ApplicationController
-  before_action :set_task, only: %i(show edit update destroy)
+  before_action :set_task, only: %i(show edit update destroy add_canceled_list)
   #before_action :set_lead_and_user_by_lead_id
   before_action :set_step, only: %i(index new create)
   before_action :set_step_in_add_delete_list, only: %i(edit_add_delete_list update_add_delete_list)
 
   def index
     @tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date)
-    @deleted_tasks_array = @step.tasks.where(status: "completed")
+    @deleted_tasks_array = @step.tasks.where(status: "completed").order(:scheduled_complete_date)
+    @canceled_tasks_array = @step.tasks.where(status: "canceled").order(:scheduled_complete_date)
     @task = @step.tasks.new
   end
 
@@ -86,7 +87,8 @@ class TasksController < Leads::ApplicationController
     end
     n1 = checkbox_array.size
     i2 = 0
-    @deleted_tasks_array = @step.tasks.where(status: "completed")
+    @deleted_tasks_array = @step.tasks.where(status: "completed").order(:scheduled_complete_date)
+
     n1.times do |i1|
       if checkbox_array[i1] == "true"
         deleted_tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date).limit(1).offset(i1 - i2)
@@ -97,6 +99,12 @@ class TasksController < Leads::ApplicationController
         end
       end
     end
+    redirect_to step_tasks_url(@step)
+  end
+
+  def add_canceled_list
+    flash[:danger] = "#{@task.name}を中止リストに追加します"
+    @task.update_attribute(:status, "canceled")
     redirect_to step_tasks_url(@step)
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < Leads::ApplicationController
-  before_action :set_task, only: %i(show edit update destroy add_canceled_list)
+  before_action :set_task, only: %i(show edit update destroy add_canceled_list revive_from_canceled_list)
   #before_action :set_lead_and_user_by_lead_id
   before_action :set_step, only: %i(index new create)
   before_action :set_step_in_add_delete_list, only: %i(edit_add_delete_list update_add_delete_list)
@@ -103,8 +103,12 @@ class TasksController < Leads::ApplicationController
   end
 
   def add_canceled_list
-    flash[:danger] = "#{@task.name}を中止リストに追加します"
     @task.update_attribute(:status, "canceled")
+    redirect_to step_tasks_url(@step)
+  end
+
+  def revive_from_canceled_list
+    @task.update_attribute(:status, "not_yet")
     redirect_to step_tasks_url(@step)
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -149,12 +149,7 @@ class TasksController < Leads::ApplicationController
     end
  
     def day_is_older_than_now(day)
-      if day.blank?
-         false
-      else
-        day_d = Date.parse(day)
-        day_d < Date.current
-      end
+      day.blank? ? false : Date.parse(day) < Date.current
     end
 
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,8 +1,8 @@
 class TasksController < Leads::ApplicationController
   before_action :set_task, only: %i(show edit update destroy)
   #before_action :set_lead_and_user_by_lead_id
-  before_action :set_step, only: %i(index new create edit_add_delete_list update_add_delete_list)
-
+  before_action :set_step, only: %i(index new create)
+  before_action :set_step_in_add_delete_list, only: %i(edit_add_delete_list update_add_delete_list)
 
   def index
     @tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date)
@@ -97,7 +97,7 @@ class TasksController < Leads::ApplicationController
         end
       end
     end
-    redirect_to lead_step_tasks_url(@lead, @step)
+    redirect_to step_tasks_url(@step)
   end
 
   private
@@ -108,6 +108,11 @@ class TasksController < Leads::ApplicationController
  
     def set_step
       @step = Step.find(params[:step_id])
+      #@step = Step.find(@task.step_id)
+    end
+
+    def set_step_in_add_delete_list
+      @step = Step.find(params[:id])
     end
 
     #Use callbacks to share common setup or constraints between actions.

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,7 +9,6 @@ class Task < ApplicationRecord
   validate :completed_date_is_invalid_if_completed_date_is_newer_than_current_date
   
   def completed_date_is_invalid_if_completed_date_is_newer_than_current_date
-    errors.add(:completed_date, "は未来の日付は入れられません") if completed_date[0, 4].to_i * 10_000 + completed_date[5, 2].to_i * 100 + completed_date[8, 2].to_i >
-                                                                                         Date.current.year * 10_000 + Date.current.month * 100 + Date.current.day
+    errors.add(:completed_date, "は未来の日付は入れられません") if completed_date.present? && Date.parse(completed_date) > Date.current
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,12 @@ class Task < ApplicationRecord
   validates :memo, length: { in: 0..400 }
   validates :scheduled_complete_date, presence: true
   enum status: [:not_yet, :completed, :canceled] # 進捗ステータス
+  
+  # 完了日が現在の日付より未来の日付を入れる場合はアラート
+  validate :completed_date_is_invalid_if_completed_date_is_newer_than_current_date
+  
+  def completed_date_is_invalid_if_completed_date_is_newer_than_current_date
+    errors.add(:completed_date, "は未来の日付は入れられません") if completed_date[0, 4].to_i * 10_000 + completed_date[5, 2].to_i * 100 + completed_date[8, 2].to_i >
+                                                                                         Date.current.year * 10_000 + Date.current.month * 100 + Date.current.day
+  end
 end

--- a/app/views/tasks/_edit_revive_from_canceled_list.html.erb
+++ b/app/views/tasks/_edit_revive_from_canceled_list.html.erb
@@ -1,0 +1,36 @@
+<% provide(:class_text, 'revive-from-canceled-list') %>
+<% provide(:button_text, '更新') %>
+
+<div class="modal-dialog modal-lg modal-dialog-center">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <h1 class="modal-title">完了予定日を入力してください</h1>
+    </div>
+    <div class="modal-body">
+      <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+          <%= form_with(model: @task, url: update_revive_from_canceled_list_task_path(@task), local: true, method: :patch) do |f| %>
+
+            <%= render partial: 'shared/error_messages' ,locals: {obj: @task} %>
+
+            <%= f.label :name, class: "label-#{yield(:class_text)}" %>
+            <p><%= @task.name %></p>
+
+            <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
+            <%= f.datetime_local_field :scheduled_complete_date, class: "form-control" %>
+
+            <div class="center">
+              <%= f.submit yield(:button_text), class: "btn btn-primary btn-#{yield(:class_text)}" %>
+              <button type="button" class="btn btn-default btn-<%= yield(:class_text) %>" data-dismiss="modal">
+                キャンセル
+              </button>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/edit_revive_from_canceled_list.js.erb
+++ b/app/views/tasks/edit_revive_from_canceled_list.js.erb
@@ -1,0 +1,2 @@
+$("#edit-revive-from-canceled-list").html("<%= escape_javascript(render 'edit_revive_from_canceled_list') %>");
+$("#edit-revive-from-canceled-list").modal("show");

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,7 +16,7 @@
               <td><%= f.check_box(:delete_task, { multiple: true, class: "check_box"}, checked_value = "true", unchecked_value = "false") %></td>
               <td><%= link_to "#{task.name}", task_path(task) %></td>
               <td><%= task.scheduled_complete_date %></td>
-              <td><%= link_to '中止', add_canceled_list_task_path(task) %>
+              <td><%= link_to '中止', add_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を中止リストに移動してよろしいですか？" } %></td>
               <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
             </tr>
           <% end %>
@@ -81,6 +81,7 @@
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.scheduled_complete_date %></td>
+            <td><%= link_to '復活', revive_from_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
             <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>
         <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -58,10 +58,10 @@
     <h3>済 リスト</h3>
     <table>
       <tbody>
-        <% @deleted_tasks_array.each do |task| %>
+        <% @completed_tasks_array.each do |task| %>
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
-            <td><%= task.scheduled_complete_date %></td>
+            <td><%= task.completed_date %></td>
             <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>
         <% end %>
@@ -74,7 +74,7 @@
         <% @canceled_tasks_array.each do |task| %>
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
-            <td><%= task.scheduled_complete_date %></td>
+            <td><%= task.canceled_date %></td>
             <td><%= link_to '復活', edit_revive_from_canceled_list_task_path(task), remote: true, data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
             <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -10,7 +10,7 @@
     <h3>To Do リスト</h3>
     <table>
       <tbody>
-        <%= form_with(model: @tasks, url: tasks_update_add_delete_list_lead_step_path(@lead,@step), local: true, mothod: :post) do |f| %>
+        <%= form_with(model: @tasks, url: tasks_update_add_delete_list_step_path(@step), local: true, mothod: :post) do |f| %>
           <% @tasks.each do |task| %>
             <tr>
               <td><%= f.check_box(:delete_task, { multiple: true, class: "check_box"}, checked_value = "true", unchecked_value = "false") %></td>
@@ -31,7 +31,7 @@
     <br>
 
 
-    <%= form_with(model: @task, url: lead_step_tasks_path(lead_id: @lead, step_id: @step), method: :post, local: true) do |f| %>
+    <%= form_with(model: @task, url: step_tasks_path(step_id: @step), method: :post, local: true) do |f| %>
   
       <%= render partial: 'shared/error_messages' ,locals: {obj: @task} %>
   
@@ -68,7 +68,7 @@
           <tr>
             <td><%= task.name %></td>
             <td><%= task.scheduled_complete_date %></td>
-            <td><%= link_to '削除', lead_step_task_path(@lead, @step ,task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
+            <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,6 +16,7 @@
               <td><%= f.check_box(:delete_task, { multiple: true, class: "check_box"}, checked_value = "true", unchecked_value = "false") %></td>
               <td><%= link_to "#{task.name}", task_path(task) %></td>
               <td><%= task.scheduled_complete_date %></td>
+              <td><%= link_to '中止', add_canceled_list_task_path(task) %>
               <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
             </tr>
           <% end %>
@@ -27,9 +28,8 @@
         <% end %>
       </tbody>
     </table>
-
-    <br>
-
+ 
+    <!-- 入力フォーム -->
 
     <%= form_with(model: @task, url: step_tasks_path(step_id: @step), method: :post, local: true) do |f| %>
   
@@ -66,7 +66,20 @@
       <tbody>
         <% @deleted_tasks_array.each do |task| %>
           <tr>
-            <td><%= task.name %></td>
+            <td><%= link_to "#{task.name}", task_path(task) %></td>
+            <td><%= task.scheduled_complete_date %></td>
+            <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <h3>中止 リスト</h3>
+    <table>
+      <tbody>
+        <% @canceled_tasks_array.each do |task| %>
+          <tr>
+            <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.scheduled_complete_date %></td>
             <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,11 +1,5 @@
-<html>
-  <% provide(:title, 'New task') %>
   <% provide(:class_text, 'task--new') %>
   <% provide(:button_text, '作成') %>
-  <head>
-    <title>マウスクリックで詳細表示</title>
-  </head>
-  <body>
     <h1>タスク一覧 </h1>
     <h3>To Do リスト</h3>
     <table>
@@ -81,18 +75,15 @@
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.scheduled_complete_date %></td>
-            <td><%= link_to '復活', revive_from_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
+            <td><%= link_to '復活', edit_revive_from_canceled_list_task_path(task), remote: true, data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
             <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
 
-    <!--%= link_to '新規作成', new_lead_step_task_path(@lead,@step) %-->
+    <!--モーダルウインドウ表示-->
+    <div id="edit-revive-from-canceled-list" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
 
-    <!--%= link_to '新規作成', new_step_task_path(@step) %-->
 
-
-  </body>
-</html>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -35,3 +35,4 @@
 
 
 <%= link_to '編集', edit_task_path(@task) %>
+<%= link_to '戻る', step_tasks_path(@step) %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -35,4 +35,5 @@
 
 
 <%= link_to '編集', edit_task_path(@task) %>
+<%= link_to '削除', task_path(@task), method: :delete, data: { confirm: "「#{@task.name}」を削除してよろしいですか？" } %>
 <%= link_to '戻る', step_tasks_path(@step) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,24 +28,19 @@ Rails.application.routes.draw do
       patch 'update_user_id'
     end
     resources :steps do
-      #member do
-        #get 'tasks/edit_add_delte_list'
-        #post 'tasks/update_add_delete_list'
-      #end
       member do
         get 'edit_status' => 'steps/step_statuses#edit', as: :edit_statuses_of
         patch 'complete' => 'steps/step_statuses#complete', as: :complete
         patch 'restart' => 'steps/step_statuses#restart', as: :restart
         patch 'cancel' => 'steps/step_statuses#cancel', as: :cancel
       end
+      member do
+        get 'tasks/edit_add_delte_list'
+        post 'tasks/update_add_delete_list'
+      end
       resources :tasks
     end
 
   end
-
-
-  get '/leads/:lead_id/steps/:step_id/tasks/edit_add_delete_list/', to: 'tasks#edit_add_delete_list', as: 'tasks_edit_add_delete_list_lead_step'
-  post '/leads/:lead_id/steps/:step_id/tasks/udate_add_delete_list', to: 'tasks#update_add_delete_list', as: 'tasks_update_add_delete_list_lead_step' 
-
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,8 @@ Rails.application.routes.draw do
       resources :tasks do
         member do
           get 'add_canceled_list'
-          get 'revive_from_canceled_list'
+          get 'edit_revive_from_canceled_list'
+          patch 'update_revive_from_canceled_list'
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,12 +35,16 @@ Rails.application.routes.draw do
         patch 'cancel' => 'steps/step_statuses#cancel', as: :cancel
       end
       member do
-        get 'tasks/edit_add_delte_list'
+        get 'tasks/edit_add_delete_list'
         post 'tasks/update_add_delete_list'
+        #get 'tasks/add_canceled_list'
       end
-      resources :tasks
+      resources :tasks do
+        member do
+          get 'add_canceled_list'
+        end
+      end
     end
-
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,11 +37,11 @@ Rails.application.routes.draw do
       member do
         get 'tasks/edit_add_delete_list'
         post 'tasks/update_add_delete_list'
-        #get 'tasks/add_canceled_list'
       end
       resources :tasks do
         member do
           get 'add_canceled_list'
+          get 'revive_from_canceled_list'
         end
       end
     end


### PR DESCRIPTION
<主な変更点>
・中止リストを作成しました。
・ToDoリストの中止ボタンを押すことで中止リストに追加。
・中止リストの復活ボタンを押すことによりToDoリストに復活。その際モーダルで「完了予定日」カラムの手動入力を要求。
<細かい変更点>
・済リストの名前を詳細ページへリンクできるようにする。
・済リストを完了予定日でソート
・詳細編集の画面に削除ボタンを設置。
・担当者のみ編集可能、削除可能。
・完了日に未来の日付を入れることはtaskモデルのvalidationで禁止。
・完了予定日、完了日に過去の日付を入れようとするとcontrollerからアラートを出す。
以上です。