### PR TITLE
ユーザー削除時のロジックを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,11 +34,7 @@ class ApplicationController < ActionController::Base
   # devise関連
   # ログイン時のリダイレクト先
   def after_sign_in_path_for(resource)
-    if current_user
-      user_path(resource)
-    else
-      root_path
-    end
+    current_user ? user_path(resource) : root_path
   end
 
   # ログアウト時のリダイレクト先
@@ -61,6 +57,7 @@ class ApplicationController < ActionController::Base
       flash[:danger] = "無効なアクセスが確認されました。"
     end
   end
+  
   protected
 
     def configure_permitted_parameters

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,6 @@ class UsersController < Users::ApplicationController
       flash[:success] = "登録に成功しました"
       redirect_to users_url
     else
-      flash.now[:danger] = "登録に失敗しました"
       render :new
     end
   end
@@ -28,17 +27,20 @@ class UsersController < Users::ApplicationController
 
   def destroy
     $DELETE_COMMAND = "Delete".freeze
-    @user = User.find(params[:command])
-    if $DELETE_COMMAND == params[:input_delete] && same_company_id_judge(@user)
-      # 現在はユーザーの持ってる案件の完了日が空文字がない場合に分岐させてます
-      if @user.leads.find_by(completed_date: "").blank?
-        @user.destroy
-        flash[:success] = "成功しました"
+    begin
+      @user = User.find(params[:command])
+      if $DELETE_COMMAND == params[:input_delete] && delete_judge(@user)
+        if @user.leads.find_by(completed_date: "").blank?
+          @user.destroy
+          flash[:success] = "成功しました"
+        else
+          flash[:danger] = "未完了の案件を担当しています。別の担当者に変えてください"
+        end
       else
-        flash[:danger] = "未完了の案件を担当しています。別の担当者に変えてください"
+        flash[:danger] = "正しく入力してください"
       end
-    else
-      flash[:danger] = "正しく入力してください"
+    rescue
+      flash[:danger] = "存在しないユーザーに対する操作を確認しました。"
     end
     redirect_to users_url
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,6 @@
 module UsersHelper
-  def same_company_id_judge(user)
-    user.company_id == current_user.company_id ? true : false
+  # 管理者を削除不可、削除対象のユーザーと削除実行ユーザーが同じ企業IDか判定
+  def delete_judge(user)
+    user.admin? || user.company_id != current_user.company_id ? false : true
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,9 +7,11 @@
     <%= user.name %>
     <%= link_to "変更", edit_other_user_registration_path(user) %>
     <!-- delete modal -->
-    <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#user-delete" data-name="<%= user.name %>" data-id="<%= user.id %>">
-      削除
-    </button>
+    <% unless user.admin? %>
+      <button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#user-delete" data-name="<%= user.name %>" data-id="<%= user.id %>">
+        削除
+      </button>
+    <% end %>
   </p>
 <% end %>
 


### PR DESCRIPTION
### 問題

管理者ユーザーしか他のユーザーを削除できないようにしていたが、
デベロッパーツールからデータを手入力で行うと
実際にユーザーを取得して削除できてしまうため修正が必要となる。

### 解決法

・管理者の削除ボタンは表示させない。
・削除時にdelete_judge(user)ヘルパーを使用し対象が管理者権限持ち又は別の企業IDを持っていないか判定しています。
・+αでユーザーIDからユーザーを見つけられなかった時(既に削除済みorまだ作られていないID)User.findでエラーが出るため例外処理で抜け出せるようにしました。
・app/controllers/application_controller.rbは三項演算子でかけると思い書き直しました。

削除に関してこれで本番環境においてもエラー画面が出ることがなくなると思います。
コードレビューよろしくお願いします。