### PR TITLE
bootstrap　ヘッダーバグ修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,5 +25,6 @@
     <% end %>
     <%= yield %>
     <%= debug(params) if Rails.env.development? %>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -75,14 +75,3 @@
     </small>
   </div>
 </main>
-<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous">
-  $('#user-delete').on('show.bs.modal', function (event) {
-    var button = $(event.relatedTarget);
-    var id = button.data('id');
-    var name = button.data('name');
-    
-    var modal = $(this);
-    modal.find('.user-id').val(id);
-    modal.find('.user-name').text(name);
-  });
-</script>


### PR DESCRIPTION
turbolinksをコメントアウトする前に発生していたバグです。
コメントアウトしてからはなぜか動作していましたが今後の為修正しました。
具体的には画面幅が狭くなったときに出てくるヘッダーリンクの内容を格納したり表示したりするボタンです。

このボタンの動作で起こっていた不具合は
Users#showでしか動作してなかったのでヘッダーが表示されるページならどこでも動作するよう修正しました。
