### PR TITLE
Change date format, etc.

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -18,6 +18,9 @@
 
 .btn-revive-from-canceled-list {
   margin: 15px 0;
-  width: 30%;
+  width: 50px;
 }
 
+input[type="date"] {
+  width: 150px;
+}

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -22,5 +22,5 @@
 }
 
 input[type="date"] {
-  width: 150px;
+  width: 200px;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -167,7 +167,7 @@ class TasksController < Leads::ApplicationController
       #stautsが「完了」のタスクの中でもっとも遅い「完了日」をこの進捗の完了日とし、現在の進捗を「完了」とする
       latest_date = @step.tasks.where(status: "completed").maximum(:completed_date)
       @step.update_attributes(completed_date: latest_date, status: "completed")
-      redirect_to lead_steps_url(@step)
+      redirect_to step_tasks_url(@step)
     # 進捗中を選択したとき
     else
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,7 @@ class TasksController < Leads::ApplicationController
 
   def create
     @task = Task.new(task_params)
-    if day_is_older_than_today(@task.scheduled_complete_date)
+    if older_than_today(@task.scheduled_complete_date)
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save && update_completed_tasks_rate(@step)
@@ -50,11 +50,11 @@ class TasksController < Leads::ApplicationController
       @task.date_blank_then_today("completed")
       # 中止にした日が空なら今日の日付を入れる
       @task.date_blank_then_today("canceled")
-      if day_is_older_than_today(@task.scheduled_complete_date) && day_is_older_than_today(@task.completed_date)
+      if older_than_today(@task.scheduled_complete_date) && older_than_today(@task.completed_date)
         flash[:danger] = "完了予定日と完了日に過去の日付を入力しようとしています。"
-      elsif day_is_older_than_today(@task.scheduled_complete_date)
+      elsif older_than_today(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-      elsif day_is_older_than_today(@task.completed_date)
+      elsif older_than_today(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
       redirect_to check_status_and_get_url
@@ -122,7 +122,7 @@ class TasksController < Leads::ApplicationController
   # 復活ボタンを押した画面から更新ボタンを押した後の処理
   def update_revive_from_canceled_list
     if @task.update_attributes(revive_from_canceled_list_params) && update_completed_tasks_rate(@step)
-      if day_is_older_than_today(@task.scheduled_complete_date)
+      if older_than_today(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
       end
       @task.update_attribute(:status, "not_yet")
@@ -140,8 +140,8 @@ class TasksController < Leads::ApplicationController
     #進捗を継続を選択したとき
     if params[:continue_or_destroy] == "continue"
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      task1 = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
-      if task1.save && update_completed_tasks_rate(@step)
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
+      if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
         redirect_to step_tasks_url(@step)
       else
@@ -171,8 +171,8 @@ class TasksController < Leads::ApplicationController
     # 進捗中を選択したとき
     else
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      task2 = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
-      if task2.save && update_completed_tasks_rate(@step)
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
+      if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
       else
         flash[:danger] = "新しいタスクの追加に失敗しました"
@@ -201,8 +201,8 @@ class TasksController < Leads::ApplicationController
       @step.update_attribute(:status, "inactive")
     #「未」のタスクをすべて「完了」を選択したとき
     else
-      #現在の進捗の「未」のタスクをすべて「完了」とし、その後complete_or_continueのurlへ飛ぶ
-      @step.tasks.where(status: "not_yet").update_all(status: "completed")
+      #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
+      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: Date.current.strftime("%Y-%m-%d"))
       update_completed_tasks_rate(@step)
     end
     redirect_to check_status_and_get_url
@@ -236,7 +236,7 @@ class TasksController < Leads::ApplicationController
     end
     
     # day空でなく、今日より前ならtrue
-    def day_is_older_than_today(day)
+    def older_than_today(day)
       day.blank? ? false : Date.parse(day) < Date.current
     end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,7 @@ class TasksController < Leads::ApplicationController
 
   def create
     @task = Task.new(task_params)
-    if older_than_today(@task.scheduled_complete_date)
+    if prohibit_future(@task.scheduled_complete_date)
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save && update_completed_tasks_rate(@step)
@@ -50,11 +50,11 @@ class TasksController < Leads::ApplicationController
       @task.date_blank_then_today("completed")
       # 中止にした日が空なら今日の日付を入れる
       @task.date_blank_then_today("canceled")
-      if older_than_today(@task.scheduled_complete_date) && older_than_today(@task.completed_date)
+      if prohibit_future(@task.scheduled_complete_date) && prohibit_future(@task.completed_date)
         flash[:danger] = "完了予定日と完了日に過去の日付を入力しようとしています。"
-      elsif older_than_today(@task.scheduled_complete_date)
+      elsif prohibit_future(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-      elsif older_than_today(@task.completed_date)
+      elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
       redirect_to check_status_and_get_url
@@ -122,7 +122,7 @@ class TasksController < Leads::ApplicationController
   # 復活ボタンを押した画面から更新ボタンを押した後の処理
   def update_revive_from_canceled_list
     if @task.update_attributes(revive_from_canceled_list_params) && update_completed_tasks_rate(@step)
-      if older_than_today(@task.scheduled_complete_date)
+      if prohibit_future(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
       end
       @task.update_attribute(:status, "not_yet")
@@ -236,7 +236,7 @@ class TasksController < Leads::ApplicationController
     end
     
     # day空でなく、今日より前ならtrue
-    def older_than_today(day)
+    def prohibit_future(day)
       day.blank? ? false : Date.parse(day) < Date.current
     end
 

--- a/app/views/tasks/_edit_revive_from_canceled_list.html.erb
+++ b/app/views/tasks/_edit_revive_from_canceled_list.html.erb
@@ -20,7 +20,7 @@
             <p><%= @task.name %></p>
 
             <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
-            <%= f.datetime_local_field :scheduled_complete_date, class: "form-control" %>
+            <%= f.date_field :scheduled_complete_date, class: "form-control" %>
 
             <div class="center">
               <%= f.submit yield(:button_text), class: "btn btn-primary btn-#{yield(:class_text)}" %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,32 +1,45 @@
-<% provide(:title, 'Edit task') %>
 <% provide(:class_text, 'task--edit') %>
 <% provide(:button_text, '更新') %>
 <h1>タスク編集</h1>
 <%= form_with(model: @task, url: task_path(@task), method: :patch, local: true) do |f| %>
 
   <%= render 'devise/shared/error_messages', resource: @task %>
-
-  <%= f.label :name, class: "label-#{yield(:class_text)}" %>
-  <%= f.text_field :name, class: "form-control" %>
-
-  <%= f.label :memo, class: "label-#{yield(:class_text)}" %>
-  <%= f.text_area :memo, class: "form-control" %>
-
-  <%= f.label :status, class: "label-#{yield(:class_text)}" %>
-  <%= f.select :status, Task.statuses.keys.map{ |k| [I18n.t("enums.task.status.#{k}"), k] }, class: "form-control" %>
-
-  <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :scheduled_complete_date, class: "form-control" %>
-
-  <%= f.label :completed_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :completed_date, class: "form-control" %>
-
-  <%= f.label :canceled_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :canceled_date, class: "form-control" %>
-
-
-  <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
-
+  <div>
+    <%= f.label :name, class: "label-#{yield(:class_text)}" %>
+    <%= f.text_field :name %>
+  </div>
+  <div>
+    <%= f.label :memo, class: "label-#{yield(:class_text)}" %>
+    <%= f.text_area :memo, class: "form-control" %>
+  </div>
+  <div>
+    <%= f.label :status, class: "label-#{yield(:class_text)}" %>
+    <%= f.select :status, Task.statuses.keys.map{ |k| [I18n.t("enums.task.status.#{k}"), k] }, class: "form-control" %>
+  </div>
+  <div>
+    <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
+    <%= f.date_field :scheduled_complete_date, value: Date.parse(@task.scheduled_complete_date) %>
+  </div>  
+  <div>
+    <%= f.label :completed_date, class: "label-#{yield(:class_text)}" %>
+    <% if @task.completed_date.present? %>
+      <%= f.date_field :completed_date, value: Date.parse(@task.completed_date) %>
+    <% else %>
+      <%= f.date_field :completed_date %>
+    <% end %>
+  </div>
+  <div>
+    <%= f.label :canceled_date, class: "label-#{yield(:class_text)}" %>
+    <% if @task.canceled_date.present? %> 
+      <%= f.date_field :canceled_date, value: Date.parse(@task.canceled_date) %>
+    <% else %>
+      <%= f.date_field :canceled_date %>
+    <% end %>
+  </div>
+  <div>
+    <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
+  </div>
   <%= f.hidden_field :step_id, class: "form-control", value: @step.id %>
 
 <% end %>
+<%= button_to '戻る', step_tasks_path(@step), method: :get, class: "btn-#{yield(:class_text)}" %>

--- a/app/views/tasks/edit_revive_from_canceled_list.html.erb
+++ b/app/views/tasks/edit_revive_from_canceled_list.html.erb
@@ -10,7 +10,7 @@
   <p><%= @task.name %></p>
 
   <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :scheduled_complete_date %>
+  <%= f.date_field :scheduled_complete_date %>
   <br>
   <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
           

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -39,7 +39,7 @@
         <div class="col-2">
           <div class="form-group">  
             <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
-            <%= f.datetime_local_field :scheduled_complete_date, class: 'form-control' %>
+            <%= f.date_field :scheduled_complete_date, class: 'form-control' %>
           </div>  
         </div> 
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -17,13 +17,13 @@
   <%= f.select :status, Task.statuses.keys.map{ |k| ["enums.task.status.#{k}", k] }, class: "form-control" %>
 
   <%= f.label :scheduled_complete_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :scheduled_complete_date, class: "form-control" %>
+  <%= f.date_field :scheduled_complete_date, class: "form-control" %>
 
   <%= f.label :completed_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :completed_date, class: "form-control" %>
+  <%= f.date_field :completed_date, class: "form-control" %>
 
   <%= f.label :canceled_date, class: "label-#{yield(:class_text)}" %>
-  <%= f.datetime_local_field :canceled_date, class: "form-control" %>
+  <%= f.date_local_field :canceled_date, class: "form-control" %>
 
 
   <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,3 +109,42 @@ puts "「SampleUser0」の案件作成完了"
   )
 end
 puts "「SampleUser0」の案件「お客様1」の進捗作成完了"
+
+# status「未」のtaskレコード作成
+3.times do |i|
+  Task.create!(
+    step_id: 1,
+    name: "task#{i+1}",
+    memo: "memo#{i+1}",
+    status: 0,
+    scheduled_complete_date: "#{Date.current + 3}",
+  )
+end
+puts "「SampleUser0」の案件「お客様１」の「進捗１」の「未」タスク作成完了"
+
+# status「完了」のtaskレコード作成
+3.times do |i|
+  Task.create!(
+    step_id: 1,
+    name: "task#{i+4}",
+    memo: "memo#{i+4}",
+    status: 1,
+    scheduled_complete_date: "#{Date.current + 4}",
+    completed_date: "#{Date.current}",
+  )
+end
+puts "「SampleUser0」の案件「お客様１」の「進捗１」の「完了」タスク作成完了"
+
+# status「中止」のtaskレコード作成
+3.times do |i|
+  Task.create!(
+    step_id: 1,
+    name: "task#{i+7}",
+    memo: "memo#{i+7}",
+    status: 2,
+    scheduled_complete_date: "#{Date.current + 5}",
+    canceled_date: "#{Date.current - 1}",
+  )
+end
+puts "「SampleUser0」の案件「お客様１」の「進捗１」の「中止」タスク作成完了"
+


### PR DESCRIPTION
<変更点>
・入力フォーム、編集フォーム、復活のフォームでdatetime_local_fieldをdate_fieldに変更して時間情報が入らないようにする。
・編集画面で既入力の完了予定日、完了日、中止にした日を自動で表示させる。
・show画面で戻るボタンを追加。
・メソッド名変更(day_is_older_than_today→older_than_today)
・編集画面で日付欄を幅狭にする。
・リダイレクト先変更。(def update_complete_or_continue_stepで現在の進捗を「完了」を選んだ時、lead_steps_url(@step)からstep_tasks_url(@step)に変更)
・def update_change_status_or_complete_taskで「未」のタスクをすべて「完了」を選んだ時、「完了日」を本日とする。
・db/seed.rbにタスクのレコードを追加。
以上です。