### PR TITLE
Revise destroy-step

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -86,12 +86,7 @@ class Leads::StepsController < Leads::ApplicationController
   # DELETE /steps/1
   # DELETE /steps/1.json
   def destroy
-    @step.destroy
-    check_status_completed_or_not(@lead, nil)
-    respond_to do |format|
-      format.html { redirect_to lead_steps_url(@lead), notice: 'Step was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    destroy_step(@lead, @step)
   end
 
   private

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -9,12 +9,11 @@ class Leads::StepsStatusesController < Leads::StepsController
       complete_step(@lead, completed_step)
       if @lead.steps_rate < 100
         flash[:success] = "#{completed_step.name}を完了しました。引き続き、#{@step.name}に取り組んでください。"
-        redirect_to @step
       else
         complete_lead(@lead)
         flash[:success] = "全ての進捗が完了し、本案件は終了済となりました。おつかれさまでした。"
-        redirect_to @lead
       end
+      redirect_to @step
     end
   end
   

--- a/app/views/leads/leads/index.html.erb
+++ b/app/views/leads/leads/index.html.erb
@@ -73,7 +73,7 @@
               </td>
               <td>
                 <div class = "tooltip-lead-index-show">
-                  <p>詳細表示</p>
+                  <p class = "btn btn-primary btn-lg">詳細表示</p>
                   <div class = "description-lead-index-show"><%= render "index_show", lead: lead %></div>
                 </div>
               </td>

--- a/app/views/leads/steps/edit.html.erb
+++ b/app/views/leads/steps/edit.html.erb
@@ -3,4 +3,5 @@
 <%= render 'form', lead: nil, step: @step %>
 
 <%= link_to 'Show', @step %> |
+<%= link_to 'Destroy', step_path(@step), method: :delete, data: { confirm: 'Are you sure?' } %> |
 <%= link_to 'Back', lead_steps_path(@lead) %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -39,19 +39,21 @@
 </div>
 <div id="collapse-step-status-edit" class="collapse">
   <div class="well">
-    <% case @step.status %>
-    <% when "not_yet" %>
-      <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
-    <% when "inactive" %>
-      <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
-    <% when "in_progress" %>
-      <button type="button" class="btn btn-info" data-toggle="modal" data-target="#step-complete" data-name="<%= @step.name %>" data-id="<%= @step.id %>">完了</button>
-      <%= render 'leads/step_statuses/cancel', step: @step %>
-    <% when "completed" %>
-      <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
-    <% when "template" %>
-      <button type="button" class="btn btn-info">このテンプレートを使用して新規作成</button>
-    <% end %>
+    <h5 style="display:inline;">
+      <% case @step.status %>
+      <% when "not_yet" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
+      <% when "inactive" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
+      <% when "in_progress" %>
+        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#step-complete" data-name="<%= @step.name %>" data-id="<%= @step.id %>">完了</button>
+        <%= render 'leads/step_statuses/cancel', step: @step %>
+      <% when "completed" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
+      <% when "template" %>
+        <button type="button" class="btn btn-info">このテンプレートを使用して新規作成</button>
+      <% end %>
+    </h5>
     <h5 style="display:inline;"><%= link_to '直接編集', edit_step_path(@step) %></h5>
   </div>
 </div>


### PR DESCRIPTION
## やったこと
* Step#destroyのメソッド化（TaskController.rbでも使うため）
* Step#destroy実行時の不具合解消
## やらないこと
* 今回「案件には一つ以上の進捗が必要」という前提が必要であることがわかりました。さもないと、案件一覧のコードが非常に煩雑になります。（進捗のない案件があると、いちいち案件に進捗があるかどうか確認する必要がある。）そもそも、進捗のない案件は、実態に合いません。したがって、Lead#createした際に、Step#newを強制するように実装する必要が生じました（別プルリクで行います）
## できるようになること(ユーザ目線)
* steps/editページから進捗を削除できるようにリンクを追加しました。
## できなくなること(ユーザ目線)
* 「不具合が生じるような進捗削除」ができなくなります。
## 動作確認
* 残り１つの進捗を削除したり、唯一の「進捗中」の進捗を削除したりした際に、処理されずに正常にエラーメッセージが表示されることを確認しました。
## その他
* 松本さん、昨日お話したdestroy_stepメソッドを作成致しました。TaskController.rbでご活用ください。
* これもまだ途中ですので、ブランチを残していただけると幸いです。
