### PR TITLE
Accordion display 2

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -87,5 +87,17 @@ class Leads::ApplicationController < Users::ApplicationController
   def calculate_rate(completed_num, not_yet_num)
     return completed_num == 0 ? 0 : 100 * completed_num / (completed_num + not_yet_num)
   end
+ 
+  def cancel_step(lead, step)
+    if step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
+      check_status_completed_or_not(lead, step)
+      flash[:success] = "#{step.name}を中止しました。以後、本進捗は通知対象になりません。"
+    else
+      # flash[:danger] = "#{step.name}の中止処理に失敗しました。システム管理者にご連絡ください。"
+      flash[:danger] = step.errors.full_messages.first
+    end
+    redirect_to step
+  end
   
+ 
 end

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -93,7 +93,6 @@ class Leads::ApplicationController < Users::ApplicationController
       check_status_completed_or_not(lead, step)
       flash[:success] = "#{step.name}を中止しました。以後、本進捗は通知対象になりません。"
     else
-      # flash[:danger] = "#{step.name}の中止処理に失敗しました。システム管理者にご連絡ください。"
       flash[:danger] = step.errors.full_messages.first
     end
     redirect_to step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -52,13 +52,6 @@ class Leads::StepsStatusesController < Leads::StepsController
   end
   
   def cancel
-#    if @step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
-#      check_status_completed_or_not(@lead, @step)
-#      flash[:success] = "#{@step.name}を中止しました。以後、本進捗は通知対象になりません。"
-#    else
-#      flash[:danger] = "#{@step.name}の中止処理に失敗しました。システム管理者にご連絡ください。"
-#    end
-#    redirect_to @step
     cancel_step(@lead, @step)
   end
   

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -52,13 +52,14 @@ class Leads::StepsStatusesController < Leads::StepsController
   end
   
   def cancel
-    if @step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
-      check_status_completed_or_not(@lead, @step)
-      flash[:success] = "#{@step.name}を中止しました。以後、本進捗は通知対象になりません。"
-    else
-      flash[:danger] = "#{@step.name}の中止処理に失敗しました。システム管理者にご連絡ください。"
-    end
-    redirect_to @step
+#    if @step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
+#      check_status_completed_or_not(@lead, @step)
+#      flash[:success] = "#{@step.name}を中止しました。以後、本進捗は通知対象になりません。"
+#    else
+#      flash[:danger] = "#{@step.name}の中止処理に失敗しました。システム管理者にご連絡ください。"
+#    end
+#    redirect_to @step
+    cancel_step(@lead, @step)
   end
   
 end

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -100,7 +100,7 @@ class Leads::TasksController < Leads::ApplicationController
         deleted_tasks.each do |deleted_task|
           deleted_task.update_attribute(:status, "completed")
           update_completed_tasks_rate(@step)
-          deleted_task.update_attribute(:completed_date, (l Date.current, format: :standard))
+          deleted_task.update_attribute(:completed_date, (l Date.current))
         end
       end
     end
@@ -111,7 +111,7 @@ class Leads::TasksController < Leads::ApplicationController
   def add_canceled_list
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
-    @task.update_attribute(:canceled_date, (l Date.current, format: :standard))
+    @task.update_attribute(:canceled_date, (l Date.current))
     redirect_to check_status_and_get_url
   end
 
@@ -140,7 +140,7 @@ class Leads::TasksController < Leads::ApplicationController
     #進捗を継続を選択したとき
     if params[:continue_or_destroy] == "continue"
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current, format: :standard))
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current))
       if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
         update_steps_rate(@lead)
@@ -179,7 +179,7 @@ class Leads::TasksController < Leads::ApplicationController
     # 進捗中を選択したとき
     else
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current, format: :standard))
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current))
       if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
         update_steps_rate(@lead)
@@ -218,13 +218,10 @@ class Leads::TasksController < Leads::ApplicationController
     when "inactive"
       #現在の進捗を「保留」とする
       cancel_step(@lead, @step)
-      #@step.update_attribute(:status, "inactive")
-      #update_steps_rate(@lead)
-      #redirect_to check_status_and_get_url
     #「未」のタスクをすべて「完了」を選択したとき
     else
       #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
-      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: (l Date.current, format: :standard))
+      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: (l Date.current))
       update_completed_tasks_rate(@step)
       redirect_to check_status_and_get_url
     end

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -204,7 +204,9 @@ class Leads::TasksController < Leads::ApplicationController
         update_steps_rate(@lead)
         redirect_to check_status_and_get_url
       else
-        render :edit_change_status_or_complete_task
+        flash[:danger] = @step.errors.full_messages.first
+        #render :edit_change_status_or_complete_task
+        redirect_to check_status_and_get_url
       end
     #進捗を「進捗中」としたとき
     when "in_progress"

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -100,7 +100,7 @@ class Leads::TasksController < Leads::ApplicationController
         deleted_tasks.each do |deleted_task|
           deleted_task.update_attribute(:status, "completed")
           update_completed_tasks_rate(@step)
-          deleted_task.update_attribute(:completed_date, Date.current.strftime("%Y-%m-%d"))
+          deleted_task.update_attribute(:completed_date, (l Date.current, format: :standard))
         end
       end
     end
@@ -111,7 +111,7 @@ class Leads::TasksController < Leads::ApplicationController
   def add_canceled_list
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
-    @task.update_attribute(:canceled_date, Date.current.strftime("%Y-%m-%d"))
+    @task.update_attribute(:canceled_date, (l Date.current, format: :standard))
     redirect_to check_status_and_get_url
   end
 
@@ -140,7 +140,7 @@ class Leads::TasksController < Leads::ApplicationController
     #進捗を継続を選択したとき
     if params[:continue_or_destroy] == "continue"
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current, format: :standard))
       if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
         update_steps_rate(@lead)
@@ -179,7 +179,7 @@ class Leads::TasksController < Leads::ApplicationController
     # 進捗中を選択したとき
     else
       #この進捗に「完了予定日」が本日で、statusが「未」の新しいタスクを追加し、現在の進捗を「進捗中」とする
-      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: Date.current.strftime("%Y-%m-%d"))
+      new_task = Task.new(step_id: @step.id ,name: "new_task", status: 0, scheduled_complete_date: (l Date.current, format: :standard))
       if new_task.save && update_completed_tasks_rate(@step)
         @step.update_attribute(:status, "in_progress")
         update_steps_rate(@lead)
@@ -224,7 +224,7 @@ class Leads::TasksController < Leads::ApplicationController
     #「未」のタスクをすべて「完了」を選択したとき
     else
       #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
-      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: Date.current.strftime("%Y-%m-%d"))
+      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: (l Date.current, format: :standard))
       update_completed_tasks_rate(@step)
       redirect_to check_status_and_get_url
     end

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -200,25 +200,32 @@ class Leads::TasksController < Leads::ApplicationController
     #進捗を「未」としたとき
     when "not_yet"
       #現在の進捗を「未」とする
-      @step.update_attribute(:status, "not_yet")
-      update_steps_rate(@lead)
+      if @step.update_attributes(status: "not_yet")
+        update_steps_rate(@lead)
+        redirect_to check_status_and_get_url
+      else
+        render :edit_change_status_or_complete_task
+      end
     #進捗を「進捗中」としたとき
     when "in_progress"
       #現在の進捗を「進捗中」とする
       @step.update_attribute(:status, "in_progress")
       update_steps_rate(@lead)
+      redirect_to check_status_and_get_url
     #進捗を「保留」としたとき
     when "inactive"
       #現在の進捗を「保留」とする
-      @step.update_attribute(:status, "inactive")
-      update_steps_rate(@lead)
+      cancel_step(@lead, @step)
+      #@step.update_attribute(:status, "inactive")
+      #update_steps_rate(@lead)
+      #redirect_to check_status_and_get_url
     #「未」のタスクをすべて「完了」を選択したとき
     else
       #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
       @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: Date.current.strftime("%Y-%m-%d"))
       update_completed_tasks_rate(@step)
+      redirect_to check_status_and_get_url
     end
-    redirect_to check_status_and_get_url
   end
   private
     def set_task

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,11 +16,11 @@ class Task < ApplicationRecord
   def date_blank_then_today(status)
     if status == "completed"
       if self.status == "completed" && self.completed_date.blank?
-        self.update_attribute(:completed_date, Date.current.strftime("%Y-%m-%d"))
+        self.update_attribute(:completed_date, (l Date.current, format: :standard))
       end
     elsif status == "canceled"
       if self.status == "canceled" && self.canceled_date.blank?
-        self.update_attribute(:canceled_date, Date.current.strftime("%Y-%m-%d"))
+        self.update_attribute(:canceled_date, (l Date.current, format: :standard))
       end
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,11 +16,11 @@ class Task < ApplicationRecord
   def date_blank_then_today(status)
     if status == "completed"
       if self.status == "completed" && self.completed_date.blank?
-        self.update_attribute(:completed_date, (l Date.current, format: :standard))
+        self.update_attribute(:completed_date, (l Date.current))
       end
     elsif status == "canceled"
       if self.status == "canceled" && self.canceled_date.blank?
-        self.update_attribute(:canceled_date, (l Date.current, format: :standard))
+        self.update_attribute(:canceled_date, (l Date.current))
       end
     end
   end

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -113,32 +113,58 @@
 
 <% end %>
 
-<p>済 リスト</p>
-<table>
-  <tbody>
-    <% @completed_tasks_array.each do |task| %>
-      <tr>
-        <td><%= link_to "#{task.name}", task_path(task) %></td>
-        <td><%= task.completed_date %></td>
-        <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<!--p>済 リスト</p-->
+<div class="panel-group" id="accordion">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <p class="panel-title">
+        <a data-toggle="collapse" data-parent="#accordion" href="#collapse3">済 リスト</a>
+      </p>
+    </div>
+    <div id="collapse3" class="panel-collapse collapse in">
+      <div class="panel-body">
+        <!--p>済 リスト</p-->
+        <table>
+          <tbody>
+            <% @completed_tasks_array.each do |task| %>
+              <tr>
+                <td><%= link_to "#{task.name}", task_path(task) %></td>
+                <td><%= task.completed_date %></td>
+                <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <p class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordion" href="#collapse4">中止 リスト</a>
+        </h4>
+      </div>
+      <div id="collapse4" class="panel-collapse collapse">
+        <div class="panel-body">
+          <!--p>中止 リスト</p-->
+          <table>
+            <tbody>
+              <% @canceled_tasks_array.each do |task| %>
+                <tr>
+                  <td><%= link_to "#{task.name}", task_path(task) %></td>
+                  <td><%= task.canceled_date %></td>
+                  <td><%= link_to '復活', edit_revive_from_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
+                  <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
-<p>中止 リスト</p>
-<table>
-  <tbody>
-    <% @canceled_tasks_array.each do |task| %>
-      <tr>
-        <td><%= link_to "#{task.name}", task_path(task) %></td>
-        <td><%= task.canceled_date %></td>
-        <td><%= link_to '復活', edit_revive_from_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
-        <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
 <!--%= link_to 'Task-index', step_tasks_path(@step) %> |-->
 <%= link_to 'Edit', edit_step_path(@step) %> |
 <%= link_to 'Back', lead_steps_path(@lead) %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -67,7 +67,7 @@
         <tr>
           <td><%= f.check_box(:delete_task, { multiple: true, class: "check_box"}, checked_value = "true", unchecked_value = "false") %></td>
           <td><%= link_to "#{task.name}", task_path(task) %></td>
-          <td><%= task.scheduled_complete_date %></td>
+          <td><%= l(Time.parse(task.scheduled_complete_date), format: :shortdate) %></td>
           <td><%= link_to '中止', add_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を中止リストに移動してよろ>しいですか？" } %></td>
           <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
         </tr>
@@ -129,7 +129,7 @@
             <% @completed_tasks_array.each do |task| %>
               <tr>
                 <td><%= link_to "#{task.name}", task_path(task) %></td>
-                <td><%= task.completed_date %></td>
+                <td><%= l(Time.parse(task.completed_date), format: :shortdate) %></td>
                 <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
               </tr>
             <% end %>
@@ -152,7 +152,7 @@
               <% @canceled_tasks_array.each do |task| %>
                 <tr>
                   <td><%= link_to "#{task.name}", task_path(task) %></td>
-                  <td><%= task.canceled_date %></td>
+                  <td><%= l(Time.parse(task.canceled_date), format: :shortdate) %></td>
                   <td><%= link_to '復活', edit_revive_from_canceled_list_task_path(task), data: { confirm: "「#{task.name}」を復活してよろしいですか？"} %>
                   <td><%= link_to '削除', task_path(task), method: :delete, data: { confirm: "「#{task.name}」を削除してよろしいですか？" } %></td>
                 </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,7 +127,7 @@ puts "「SampleUser0」の案件「お客様1」の進捗作成完了"
     name: "task#{i+1}",
     memo: "memo#{i+1}",
     status: 0,
-    scheduled_complete_date: (I18n.l Date.current + 3, format: :standard),
+    scheduled_complete_date: (I18n.l Date.current + 3),
   )
 end
 
@@ -138,8 +138,8 @@ end
     name: "task#{i+4}",
     memo: "memo#{i+4}",
     status: 1,
-    scheduled_complete_date: (I18n.l Date.current + 4, format: :standard),
-    completed_date: (I18n.l Date.current, format: :standard),
+    scheduled_complete_date: (I18n.l Date.current + 4),
+    completed_date: (I18n.l Date.current),
   )
 end
 
@@ -150,8 +150,8 @@ end
     name: "task#{i+7}",
     memo: "memo#{i+7}",
     status: 2,
-    scheduled_complete_date: (I18n.l Date.current + 5, format: :standard),
-    canceled_date: (I18n.l Date.current - 1, format: :standard),
+    scheduled_complete_date: (I18n.l Date.current + 5),
+    canceled_date: (I18n.l Date.current - 1),
   )
 end
 puts "「SampleUser0」の案件「お客様１」の「進捗１」のタスク作成完了"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,10 +127,9 @@ puts "「SampleUser0」の案件「お客様1」の進捗作成完了"
     name: "task#{i+1}",
     memo: "memo#{i+1}",
     status: 0,
-    scheduled_complete_date: "#{Date.current + 3}",
+    scheduled_complete_date: (I18n.l Date.current + 3, format: :standard),
   )
 end
-puts "「SampleUser0」の案件「お客様１」の「進捗１」の「未」タスク作成完了"
 
 # status「完了」のtaskレコード作成
 3.times do |i|
@@ -139,11 +138,10 @@ puts "「SampleUser0」の案件「お客様１」の「進捗１」の「未」
     name: "task#{i+4}",
     memo: "memo#{i+4}",
     status: 1,
-    scheduled_complete_date: "#{Date.current + 4}",
-    completed_date: "#{Date.current}",
+    scheduled_complete_date: (I18n.l Date.current + 4, format: :standard),
+    completed_date: (I18n.l Date.current, format: :standard),
   )
 end
-puts "「SampleUser0」の案件「お客様１」の「進捗１」の「完了」タスク作成完了"
 
 # status「中止」のtaskレコード作成
 3.times do |i|
@@ -152,9 +150,9 @@ puts "「SampleUser0」の案件「お客様１」の「進捗１」の「完了
     name: "task#{i+7}",
     memo: "memo#{i+7}",
     status: 2,
-    scheduled_complete_date: "#{Date.current + 5}",
-    canceled_date: "#{Date.current - 1}",
+    scheduled_complete_date: (I18n.l Date.current + 5, format: :standard),
+    canceled_date: (I18n.l Date.current - 1, format: :standard),
   )
 end
-puts "「SampleUser0」の案件「お客様１」の「進捗１」の「中止」タスク作成完了"
+puts "「SampleUser0」の案件「お客様１」の「進捗１」のタスク作成完了"
 


### PR DESCRIPTION
## やったこと
1.cancel stepメソッドの導入。基本設計書-タスクコントロール-19行目「完了済進捗編集時イベント」で現在の進捗で「未」、「保留」を選び、stepのバリデーションエラーになったときのエラーハンドリングしました。
2.タスクの済リストと中止リストをアコーディオン表示にしました。
3.日付の設定にstrftimeの替わりにl メソッドを用いて書き換えました。
## やらないこと
https://github.com/taniryuu/Rer_Pro/pull/84
未マージの為destroy_stepメソッドは使用していません。
## できるようになること(ユーザ目線)
タスクの完了済進捗編集時イベントで現在の進捗で「未」、「保留」を選びstepのバリデーションエラーになったとき、
適切なエラーメッセージを取得できる。
タスクの済リストと中止リストをアコーディオンで表示できる。
## できなくなること(ユーザ目線)
タスクの済リストと中止リストのクリックなしの一覧表示はできなくなった。
## 動作確認
db/seed.rbファイルによるrails seed。タスクのCURD操作。削除チェックボックス、中止ボタン、復活ボタンの機能確認。check_status_and_get_urlメソッドが正しく動作すること。
## その他
l メソッドのデフォルトの日付フォーマットは"%Y/%m/%d"ですが、フォームから日付を入力する場合"%Y-%m-%d"になりますので、lメソッドの方もこれに合わせるため、lメソッドでformat: :standardオプションを付けて、フォーマットを"%Y-%m-%d"に統一しました。
