### PR TITLE
start_stepメソッド追加　＆　Lead#createしたときに自動でStep#create

### DIFF
--- a/app/controllers/leads/leads_controller.rb
+++ b/app/controllers/leads/leads_controller.rb
@@ -56,7 +56,15 @@ class Leads::LeadsController < Leads::ApplicationController
     @lead = current_user.leads.new(lead_params)
     respond_to do |format|
       if @lead.save && update_steps_rate(@lead)
-        format.html { redirect_to new_lead_step_path(@lead), notice: '案件を作成しました。引き続き進捗を登録してください。' }
+        # 将来的には、上長の設定したテンプレートの進捗が自動生成されるようにしたい。
+        # （ある程度決まったプロセスなのに一から進捗をつくるのはUXとして非現実的。）↓は仮。
+        @step = @lead.steps.create!(
+          name: "進捗(仮)",
+          status: 2,
+          order: 1,
+          scheduled_complete_date: "#{Date.current}",
+        )
+        format.html { redirect_to edit_step_path(@step), notice: '案件を作成しました。引き続き進捗を登録してください。' }
         format.json { render :show, status: :created, location: @lead }
       else
         format.html { render :new }

--- a/app/controllers/leads/leads_controller.rb
+++ b/app/controllers/leads/leads_controller.rb
@@ -54,10 +54,9 @@ class Leads::LeadsController < Leads::ApplicationController
   # POST /leads.json
   def create
     @lead = current_user.leads.new(lead_params)
-
     respond_to do |format|
       if @lead.save && update_steps_rate(@lead)
-        format.html { redirect_to @lead, notice: 'Lead was successfully created.' }
+        format.html { redirect_to new_lead_step_path(@lead), notice: '案件を作成しました。引き続き進捗を登録してください。' }
         format.json { render :show, status: :created, location: @lead }
       else
         format.html { render :new }

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -18,36 +18,7 @@ class Leads::StepsStatusesController < Leads::StepsController
   end
   
   def start
-    ActiveRecord::Base.transaction do
-      case @step.status
-        when "not_yet"
-          @success_message = "#{@step.name}を開始しました。" if @step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date])
-        when "inactive"
-          @success_message = "#{@step.name}を再開しました。" if @step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], canceled_date: "")
-        when "in_progress"
-          @success_message = "#{@step.name}は既に進捗中です。"
-        when "completed"
-          @success_message = "#{@step.name}を再開しました。" if @step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], completed_date: "")
-      end
-      update_completed_tasks_rate(@step)
-      if params[:completed_id].present?
-        completed_step = Step.find(params[:completed_id])
-        complete_step(@lead, completed_step)
-        @success_message = "#{completed_step.name}を完了し、#{@step.name}を開始しました。"
-      else
-        update_steps_rate(@lead)
-      end
-      check_status_completed_or_not(@lead, @step)
-      raise ActiveRecord::Rollback if @lead.errors.present? || @step.errors.present?
-    end
-    
-    if @step.errors.present?
-      flash[:danger] = "完了予定日が正しく入力されていません。空欄は不可です。"
-    else
-      flash[:success] = @success_message
-    end
-    redirect_to @step
-        
+    start_step(@lead, @step)
   end
   
   def cancel

--- a/app/views/leads/leads/index.html.erb
+++ b/app/views/leads/leads/index.html.erb
@@ -79,16 +79,10 @@
                   </div>
                 </td>
               <% elsif lead.user_id == current_user.id %>
-                <td>
-                  <%= link_to '進捗を作成', new_lead_step_path(lead), class: "btn btn-primary btn-sm" if lead.user_id == current_user.id %>
-                </td>
-                <td>
-                  <%= link_to '編集', edit_lead_path(lead), class: "btn btn-primary btn-sm" if lead.user_id == current_user.id %>
-                </td>
+                <td><%= link_to '進捗を作成', new_lead_step_path(lead), class: "btn btn-primary btn-sm" %></td>
+                <td><%= link_to '編集', edit_lead_path(lead), class: "btn btn-primary btn-sm" %></td>
               <% else %>
-                <td colspan="2">
-                  <%= "申込日：#{l(Time.parse(lead.created_date), format: :shortdate)}" %>
-                </td>
+                <td colspan="2"><%= "申込日：#{l(Time.parse(lead.created_date), format: :shortdate)}" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/leads/leads/index.html.erb
+++ b/app/views/leads/leads/index.html.erb
@@ -67,16 +67,29 @@
               <td><%= lead.customer_name %></td>
               <td><%= l(Time.parse(lead.scheduled_resident_date), format: :shortdate) %></td>
               <td><%= l(Time.parse(lead.scheduled_payment_date), format: :shortdate) %></td>
-              <td>
-                <%= "#{latest_step_in(lead).name}:#{latest_step_in(lead).status_i18n}" %><br>
-                <%= "(#{lead.steps_rate}%)" %>
-              </td>
-              <td>
-                <div class = "tooltip-lead-index-show">
-                  <p class = "btn btn-primary btn-lg">詳細表示</p>
-                  <div class = "description-lead-index-show"><%= render "index_show", lead: lead %></div>
-                </div>
-              </td>
+              <% if lead.steps.first.present? %>
+                <td>
+                  <%= "#{latest_step_in(lead).name}:#{latest_step_in(lead).status_i18n}" %><br>
+                  <%= "(#{lead.steps_rate}%)" %>
+                </td>
+                <td>
+                  <div class = "tooltip-lead-index-show">
+                    <p class = "btn btn-primary btn-lg">詳細表示</p>
+                    <div class = "description-lead-index-show"><%= render "index_show", lead: lead %></div>
+                  </div>
+                </td>
+              <% elsif lead.user_id == current_user.id %>
+                <td>
+                  <%= link_to '進捗を作成', new_lead_step_path(lead), class: "btn btn-primary btn-sm" if lead.user_id == current_user.id %>
+                </td>
+                <td>
+                  <%= link_to '編集', edit_lead_path(lead), class: "btn btn-primary btn-sm" if lead.user_id == current_user.id %>
+                </td>
+              <% else %>
+                <td colspan="2">
+                  <%= "申込日：#{l(Time.parse(lead.created_date), format: :shortdate)}" %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -2,12 +2,12 @@
   <%= render 'devise/shared/error_messages', resource: @step %>
 
   <div class="field">
-    <%= form.label :name %>
+    <%= form.label :name %>＜入力必須＞
     <%= form.text_field :name, autofocus: true %>
   </div>
 
   <div class="field">
-    <%= form.label :order %>
+    <%= form.label :order %>＜入力必須＞
     <% plus = step.new_record? ? 1 : 0 %>
     <%= form.number_field :order, min: 1, max: @lead.steps.count + plus %>
   </div>
@@ -29,9 +29,8 @@
     </div>
   
     <div class="field">
-      <%= form.label :scheduled_complete_date %>
+      <%= form.label :scheduled_complete_date %>＜入力必須＞
       <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %>
-      （入力必須）
     </div>
   
   <% else %>
@@ -43,13 +42,13 @@
   
     <div class="field">
       <%= form.label :scheduled_complete_date %>
-      <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %>
+      <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %><br>
       ↑ 進捗中の進捗の場合、入力必須<br>
     </div>
   
     <div class="field">
       <%= form.label :completed_date %>
-      <%= form.date_field :completed_date, value: step.completed_date %>
+      <%= form.date_field :completed_date, value: step.completed_date %><br>
       ↑ 完了済の進捗の場合、入力必須<br>
     </div>
     


### PR DESCRIPTION
## やったこと
* start_stepメソッド（Stepレコードを"in_progress"にupdateするメソッド）を追加
* Lead#createしたときに、自動でStep#createされるように追加（念のため、stepがなくてもLead-indexでエラーが出ないようにしました。）
## やらないこと
* バリデーションで不具合を発見しました。次回プルリクで修正致します。
## できるようになること(ユーザ目線)
* 案件を新規作成した際に、進捗の作成画面へ飛ぶ。（自動で作成された進捗を編集する形式）
* 時間のないときは、そのままでもエラーは出ない。
## できなくなること(ユーザ目線)
* 進捗レコードなしの案件を作成すること
## 動作確認
* 進捗の再開や案件の作成などを行い、エラーが出ないことを確認しました。
## その他
* 松本さん、下記プルリクでお話したstart_stepメソッドを作成致しましたので、ご活用ください。
https://github.com/taniryuu/Rer_Pro/pull/85
* 引き続き、ブランチを残していただけると幸いです。
