### PR TITLE
Lead show page

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -6,14 +6,14 @@ class Leads::ApplicationController < Users::ApplicationController
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
       case step.status
-        when "not_yet"
-          @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date])
-        when "inactive"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], canceled_date: "")
-        when "in_progress"
-          @success_message = "#{step.name}は既に進捗中です。"
-        when "completed"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], completed_date: "")
+      when "not_yet"
+        @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date])
+      when "inactive"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], canceled_date: "")
+      when "in_progress"
+        @success_message = "#{step.name}は既に進捗中です。"
+      when "completed"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: params[:step][:scheduled_complete_date], completed_date: "")
       end
       if params[:completed_id].present?
         completed_step = Step.find(params[:completed_id])
@@ -22,42 +22,55 @@ class Leads::ApplicationController < Users::ApplicationController
       check_status_completed_or_not(lead, step)
       raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status) || step.errors.present?
     end
-    
-    flash[:danger] = lead.errors.full_messages.first if lead.errors.present?
-    flash[:danger] = step.errors.full_messages.first if step.errors.present?
-    flash[:success] = @success_message if @success_message.present?
+    if lead.errors.blank? && step.errors.blank?
+      flash[:success] = @success_message if @success_message.present?
+    else
+      flash.delete(:success)
+      flash[:danger] = lead.errors.full_messages.first if lead.errors.present?
+      flash[:danger] = step.errors.full_messages.first if step.errors.present?
+    end
     redirect_to step
   end
   
   # 進捗の中止処理を実行し詳細ページへ遷移
   def cancel_step(lead, step)
-    if step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
+    ActiveRecord::Base.transaction do
+      step.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
       check_status_completed_or_not(lead, step)
+      raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status) || step.errors.present?
+    end
+    if lead.errors.blank? && step.errors.blank?
       flash[:success] = "#{step.name}を中止しました。以後、本進捗は通知対象になりません。"
     else
       flash[:danger] = step.errors.full_messages.first
+      flash[:danger] = lead.errors.full_messages.first
     end
     redirect_to step
   end
   
+  # 進捗の中止状態を確認し、他カラムとの整合性を担保
+  def check_status_inactive_or_not(step)
+    if step.status == "inactive" && step.canceled_date.blank?
+      step.update_attribute(:canceled_date, "#{Date.current}")
+    elsif step.status != "inactive" && step.canceled_date.present?
+      step.update_attribute(:canceled_date, "")
+    end
+  end
+  
   # 進捗の削除処理を実行し詳細ページへ遷移
   def destroy_step(lead, step)
-    # 本来ならモデルでvalidateしたい内容だが、削除後にバリデーションを通して失敗したらrollback、という実装に時間がかかりそうなので、とりあえずfatコントローラで対応した。
-    steps_except_self = lead.steps.not_self(step).ord
-    if steps_except_self.blank?
-      flash[:danger] = "#{step.name}を削除できません。案件には、進捗が少なくとも一つ以上必要です。"
-    elsif lead.status == "in_progress" && steps_except_self.in_progress.blank?
-      flash[:danger] = "#{step.name}を削除できません。進捗中の案件には、進捗中の進捗が少なくとも一つ以上必要です。"
-    elsif lead.status == "completed" && steps_except_self.completed.blank?
-      flash[:danger] = "#{step.name}を削除できません。終了済の案件には、完了済の進捗が少なくとも一つ以上必要です。"
-    elsif lead.status == "inactive" && steps_except_self.inactive.blank?
-      flash[:danger] = "#{step.name}を削除できません。凍結中の案件には、中止した進捗が少なくとも一つ以上必要です。"
-    else
+    ActiveRecord::Base.transaction do
       step.destroy
       check_status_completed_or_not(lead, nil)
-      flash[:success] = "#{step.name}を削除しました。"
+      raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status)
     end
-    redirect_to Step.find_by(id: step.id).present? ? step : working_step_in(lead)
+    if lead.errors.blank?
+      flash[:success] = "#{step.name}を削除しました。"
+      redirect_to working_step_in(lead)
+    else
+      flash[:danger] = "#{step.name}を削除できませんでした。#{lead.errors.full_messages.first}"
+      redirect_to step
+    end
   end
   
   # 本日付で案件の完了処理を実行
@@ -149,9 +162,4 @@ class Leads::ApplicationController < Users::ApplicationController
     return completed_num == 0 ? 0 : 100 * completed_num / (completed_num + not_yet_num)
   end
   
-  # statusを確認して真偽値を出力
-  def status?(model, status_name)
-    model.status == status_name
-  end
- 
 end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -12,22 +12,22 @@ class Leads::StepsController < Leads::ApplicationController
   # GET /steps
   # GET /steps.json
   def index
-    @steps = @lead.steps.all.order(:order)
+    @steps = @lead.steps.all.ord
   end
 
   # GET /steps/1
   # GET /steps/1.json
   def show
-    @steps = @lead.steps.all.order(:order)
-    @steps_except_self = @lead.steps.where.not(id: @step.id).order(:order)
-    @steps_from_now_on = @steps_except_self.where(status: ["not_yet", "in_progress"]).order(:order)
+    @steps = @lead.steps.all.ord
+    @steps_except_self = @steps.not_self(@step)
+    @steps_from_now_on = @steps_except_self.todo
     
     # タスクステータスが「未」のリスト
-    @tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date)
+    @tasks = @step.tasks.not_yet.order(:scheduled_complete_date)
     # タスクステータスが「完了」のリスト
-    @completed_tasks_array = @step.tasks.where(status: "completed").order(:completed_date)
+    @completed_tasks_array = @step.tasks.completed.order(:completed_date)
     # タスクステータスが「中止」のリスト
-    @canceled_tasks_array = @step.tasks.where(status: "canceled").order(:canceled_date)
+    @canceled_tasks_array = @step.tasks.canceled.order(:canceled_date)
     @task = @step.tasks.new
   end
 
@@ -50,7 +50,7 @@ class Leads::StepsController < Leads::ApplicationController
       if save_and_errors_of(@step).blank?
         @completed_step = Step.find(completed_id) # save_and_errors_ofメソッドの後で定義する。さもないと、上の行で順序が変更になった際にcompleteメソッドでエラーを吐く。
         complete_step(@lead, @completed_step)
-        flash[:success] = "#{@completed_step.name}を完了し、#{@step.name}を開始しました。"
+        flash[:success] = "#{flash[:success]}#{@completed_step.name}を完了し、#{@step.name}を開始しました。"
         redirect_to @step
       else
         @completed_step = Step.find(completed_id) # 完了処理が終わっていないので改めてオブジェクトを渡す。

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,13 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  scope :not_self, -> (model) { where.not(id: model.id) }
+  scope :todo, -> { where(status: ["not_yet", "in_progress"]) }
+  scope :not_yet, -> { where(status: "not_yet") }
+  scope :inactive, -> { where(status: "inactive") }
+  scope :in_progress, -> { where(status: "in_progress") }
+  scope :completed, -> { where(status: "completed") }
+  scope :template, -> { where(status: "template") }
+  scope :canceled, -> { where(status: "canceled") }
   
   # 完了日は未来の日付禁止
   def completed_date_prohibit_future

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -19,6 +19,7 @@ class Lead < ApplicationRecord
   with_options if: proc { |s| s.template? } do |model|
     model.validates :template_name, presence: true, length: { minimum: 2 }
   end
+  validate :match_steps_status, on: :check_steps_status
   enum status:[:in_progress, :completed, :inactive] # 案件ステータス
   
   # 案件検索機能。
@@ -26,4 +27,16 @@ class Lead < ApplicationRecord
     return Lead.all unless search_word
     Lead.where(["#{search_column} LIKE ?", "%#{search_word}%"])
   end
+  
+  # 進捗の:statusは、案件のstatusに対応するstatusが必要。@lead.valid?(:check_steps_status)したときのみバリデーションを実行。
+  def match_steps_status
+    if self.status == "in_progress" && self.steps.in_progress.blank?
+      errors.add(:status, ":進捗中の案件には、進捗中の進捗が少なくとも一つ以上必要です。")
+    elsif self.status == "completed" && self.steps.completed.blank?
+      errors.add(:status, ":完了済の案件には、完了済の進捗が少なくとも一つ以上必要です。")
+    elsif self.status == "inactive" && self.steps.inactive.blank?
+      errors.add(:status, ":凍結中の案件には、凍結中の進捗が必要です。")
+    end
+  end
+  
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -7,7 +7,7 @@ class Step < ApplicationRecord
   validates :memo, length: { in: 0..400 }
   validates :order, presence: true, uniqueness: { scope: :lead_id }, 
                     numericality: {only_integer: true, greater_than_or_equal_to: 1}
-  validate :order_is_serial_number
+  validate :order_is_serial_number, on: :check_order
   validates :status, presence: true
   validates :scheduled_complete_date, presence: true, length: { in: 0..32 }, if: -> { status == "in_progress" }
   validates :completed_date, presence: true, length: { in: 0..32 }, if: -> { status == "completed" }
@@ -15,11 +15,11 @@ class Step < ApplicationRecord
   validates :completed_tasks_rate, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100}
   enum status:[:not_yet, :inactive, :in_progress, :completed, :template] # 進捗ステータス
   
-  # :orderカラムが連番であることを保証するには、最大値がレコードの数と一致する必要があるが、更新の都合上1つ余裕を持たせている。
+  # :orderカラムが連番であることを保証するには、最大値がレコードの数と一致する必要がある。@step.valid?(:check_order)したときのみバリデーションを実行。
   def order_is_serial_number
     steps_of_same_lead = Step.where(lead_id: self.lead_id)
     if steps_of_same_lead.present?
-      unless steps_of_same_lead.pluck(:order).max <= steps_of_same_lead.count + 1
+      unless steps_of_same_lead.pluck(:order).max <= steps_of_same_lead.count
         errors.add(:order, "が「1から始まる連番」になっていません。")
       end
     end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,7 +1,7 @@
 class Step < ApplicationRecord
   belongs_to :lead
   has_many :tasks, dependent: :destroy
-  default_scope -> { order(order: :asc) }
+  scope :ord, -> { order(:order) }
   
   validates :name, presence: true, length: { in: 2..50 }
   validates :memo, length: { in: 0..400 }
@@ -9,7 +9,6 @@ class Step < ApplicationRecord
                     numericality: {only_integer: true, greater_than_or_equal_to: 1}
   validate :order_is_serial_number
   validates :status, presence: true
-  validate :match_status_with_lead
   validates :scheduled_complete_date, presence: true, length: { in: 0..32 }, if: -> { status == "in_progress" }
   validates :completed_date, presence: true, length: { in: 0..32 }, if: -> { status == "completed" }
   validate :completed_date_prohibit_future
@@ -23,18 +22,6 @@ class Step < ApplicationRecord
       unless steps_of_same_lead.pluck(:order).max <= steps_of_same_lead.count + 1
         errors.add(:order, "が「1から始まる連番」になっていません。")
       end
-    end
-  end
-  
-  # 進捗の:statusは、案件のstatusに対応するstatusが必要
-  def match_status_with_lead
-    lead = Lead.find(self.lead_id)
-    if lead.status == "in_progress" && lead.steps.find_by(status: "in_progress").blank?
-      errors.add(:status, ":進捗中の案件には、進捗中の進捗が少なくとも一つ以上必要です。") unless self.status == "in_progress"
-    elsif lead.status == "completed" && lead.steps.find_by(status: "completed").blank?
-      errors.add(:status, ":完了済の案件には、完了済の進捗が少なくとも一つ以上必要です。") unless self.status == "completed"
-    elsif lead.status == "inactive" && lead.steps.find_by(status: "inactive").blank?
-      errors.add(:status, ":凍結中の案件には、凍結中の進捗が必要です。") unless self.status == "inactive"
     end
   end
   

--- a/app/views/leads/leads/index.html.erb
+++ b/app/views/leads/leads/index.html.erb
@@ -69,7 +69,7 @@
               <td><%= l(Time.parse(lead.scheduled_payment_date), format: :shortdate) %></td>
               <% if lead.steps.first.present? %>
                 <td>
-                  <%= "#{latest_step_in(lead).name}:#{latest_step_in(lead).status_i18n}" %><br>
+                  <%= "#{latest_step_in(lead).status_i18n}" %><br>
                   <%= "(#{lead.steps_rate}%)" %>
                 </td>
                 <td>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -15,6 +15,7 @@
   <% step_button_color = (step.id == @step.id) ? "danger" : "info" %>
   <%= link_to "#{step.order}", step_path(step), class: "btn btn-#{step_button_color} btn-lg" %>
 <% end %>
+<%= link_to "追加", new_lead_step_path(@lead), class: "btn btn-default btn-lg" %>
 
 <br>////////////////////////////////////////////////////////////////////////////////////////////////////////////<br>
 
@@ -34,7 +35,7 @@
     <% when "template" %>
     <% end %>
   <a class="btn btn-default" data-toggle="collapse" href="#collapse-step-status-edit">
-    編集
+    編集▼
   </a>
 </div>
 <div id="collapse-step-status-edit" class="collapse">


### PR DESCRIPTION
## やったこと
* 下記のバリデーションが厳しく、何かと悪さをするため、手動でトリガーを引く仕様に変更した。具体的には、トランザクションでまとめて変更処理をしてから、最後にバリデーションをチェックする仕様とした。
　　 - 案件のstatusに応じたstatusの進捗が必要
　　 - 進捗の順番が連番となること
* 上記変更は、下記アクション、メソッドに適用
　　 - アクション：Step#create / update
　　 - メソッド：destroy_step / cancel_step / start_step
* scopeを導入した。
## やらないこと
* 肝心の案件詳細ページの実装が未だです・・・
## できるようになること(ユーザ目線)
* 特になし
## できなくなること(ユーザ目線)
* エラーを起こすような操作ができなくなります。
## 動作確認
* StepのCRUDを行う中で、わざと変な値を入れてみたり、途中で戻るボタンを押したりして、エラー画面にならないことを確認しました。
## その他
* わかりにくい箇所がありましたらご指摘ください。コメントなどでなるべく可読性が上がるようにしたつもりではいますが・・・
* scopeは積極的に使用ください。status関連の条件分岐が多いので、次回プルリクでメソッドも追加予定です。
