### PR TITLE
Feature/notification logic

### DIFF
--- a/app/assets/javascripts/notifications.coffee
+++ b/app/assets/javascripts/notifications.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the notifications controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # ログインしているユーザーがいる企業の社員全員取得
-  def set_member
+  def set_users
     @users = current_user.users_in_company
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # ログインしているユーザーがいる企業の社員全員取得
-  def set_members
+  def set_member
     @users = current_user.users_in_company
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,32 +1,44 @@
 class NotificationsController < Users::ApplicationController
   before_action :set_member
 
-  # 上長視点の通知
+  # superior_idに指定されたユーザー視点の通知
   def notice
     @create_notices_list = [] # 新規作成時の通知をユーザー毎に取得して配列に格納
     @limit_change_notices_list = [] # 完了予定日変更時の通知をユーザー毎に取得して配列に格納
+    @others_limit_notices_list = [] # superior_idに指定されたユーザーに届く通知をユーザー毎に取得して配列に格納
     @create_notices_user_num = [] # 新規作成時の案件のuser_idを取得
     @limit_change_notices_user_num = [] # 完了予定日変更時の案件のuser_idを取得
+    @others_limit_notices_user_num = [] # superior_idに指定されたユーザーに届く通知を取得
     @create_notices_total_count = 0 # 新規作成時の通知件数を格納
     @limit_change_notices_total_count = 0 # 完了予定日変更時の通知件数を格納
-    
-    # @usersを通知送信先がcurrent_user.id,statusがactiveのユーザーに絞る
+    @others_limit_notices_total_count = 0 # superior_idに指定されたユーザーに届く通知件数を格納
+    # 企業内の全ユーザーから通知送信先がcurrent_user.id,statusがactiveのユーザーに絞る
     users = @users.where(status: "active")
                   .where(superior_id: current_user.id)
     users.each do |user|
       leads = user.leads.where(status: "in_progress")
+      limit_date = Date.current + user.notified_num
       if leads.present?
         # 案件create時の通知一覧
-        if leads.where(notice_created: true).present?
-          @create_notices_total_count += leads.count
-          @create_notices_list.push(leads.where(notice_created: true)) 
+        @create_notices = leads.where(notice_created: true)
+        if @create_notices.present?
+          @create_notices_total_count += @create_notices.count
+          @create_notices_list.push(@create_notices)
           @create_notices_user_num.push(leads.select(:user_id).distinct)
         end
         # 案件完了予定日を変更時の通知一覧
-        if leads.where(notice_change_limit: true).present?
-          @limit_change_notices_total_count += leads.count
-          @limit_change_notices_list.push(leads.where(notice_change_limit: true))
+        @limit_change_notices = leads.where(notice_change_limit: true)
+        if @limit_change_notices.present?
+          @limit_change_notices_total_count += @limit_change_notices.count
+          @limit_change_notices_list.push(@limit_change_notices)
           @limit_change_notices_user_num.push(leads.select(:user_id).distinct)
+        end
+        # 案件完了予定日の期限と現在の日付が同じ且つ過ぎている時
+        @others_limit_notices = leads.where("scheduled_contract_date <= ?", limit_date)
+        if @others_limit_notices.present?
+          @others_limit_notices_total_count += @others_limit_notices.count
+          @others_limit_notices_list.push(@others_limit_notices)
+          @others_limit_notices_user_num.push(leads.select(:user_id).distinct)
         end
       end
     end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -16,29 +16,28 @@ class NotificationsController < Users::ApplicationController
     users = @users.where(status: "active")
                   .where(superior_id: current_user.id)
     users.each do |user|
-      leads = user.leads.where(status: "in_progress")
-      limit_date = Date.current + user.notified_num
+      leads = user.leads.in_progress
       if leads.present?
         # 案件create時の通知一覧
-        @create_notices = leads.where(notice_created: true)
-        if @create_notices.present?
-          @create_notices_total_count += @create_notices.count
-          @create_notices_list.push(@create_notices)
-          @create_notices_user_num.push(leads.select(:user_id).distinct)
+        create_notices = leads.where(notice_created: true)
+        if create_notices.present?
+          @create_notices_total_count += create_notices.count
+          @create_notices_list.push(create_notices)
+          @create_notices_user_num.push(user.id)
         end
         # 案件完了予定日を変更時の通知一覧
-        @limit_change_notices = leads.where(notice_change_limit: true)
-        if @limit_change_notices.present?
-          @limit_change_notices_total_count += @limit_change_notices.count
-          @limit_change_notices_list.push(@limit_change_notices)
-          @limit_change_notices_user_num.push(leads.select(:user_id).distinct)
+        limit_change_notices = leads.where(notice_change_limit: true)
+        if limit_change_notices.present?
+          @limit_change_notices_total_count += limit_change_notices.count
+          @limit_change_notices_list.push(limit_change_notices)
+          @limit_change_notices_user_num.push(user.id)
         end
         # 案件完了予定日の期限と現在の日付が同じ且つ過ぎている時
-        @others_limit_notices = leads.where("scheduled_contract_date <= ?", limit_date)
-        if @others_limit_notices.present?
-          @others_limit_notices_total_count += @others_limit_notices.count
-          @others_limit_notices_list.push(@others_limit_notices)
-          @others_limit_notices_user_num.push(leads.select(:user_id).distinct)
+        others_limit_notices = leads.where.not(scheduled_contract_date: "").where("scheduled_contract_date <= ?", user.limit_date)
+        if others_limit_notices.present?
+          @others_limit_notices_total_count += others_limit_notices.count
+          @others_limit_notices_list.push(others_limit_notices)
+          @others_limit_notices_user_num.push(user.id)
         end
       end
     end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,26 +3,32 @@ class NotificationsController < Users::ApplicationController
 
   # 上長視点の通知
   def notice
-    @member =[]
-    create_notices = []
-    limit_change_notices = []
+    @create_notices_list = [] # 新規作成時の通知をユーザー毎に取得して配列に格納
+    @limit_change_notices_list = [] # 完了予定日変更時の通知をユーザー毎に取得して配列に格納
+    @create_notices_user_num = [] # 新規作成時の案件のuser_idを取得
+    @limit_change_notices_user_num = [] # 完了予定日変更時の案件のuser_idを取得
+    @create_notices_total_count = 0 # 新規作成時の通知件数を格納
+    @limit_change_notices_total_count = 0 # 完了予定日変更時の通知件数を格納
+    
     # @usersを通知送信先がcurrent_user.id,statusがactiveのユーザーに絞る
-    users = @users.where(superior_id: current_user.id)
-                  .where(status: "active")
+    users = @users.where(status: "active")
+                  .where(superior_id: current_user.id)
     users.each do |user|
-      user.leads.each do |lead|
+      leads = user.leads.where(status: "in_progress")
+      if leads.present?
         # 案件create時の通知一覧
-        if lead.notice_created == true
-          create_notices.push(lead)
+        if leads.where(notice_created: true).present?
+          @create_notices_total_count += leads.count
+          @create_notices_list.push(leads.where(notice_created: true)) 
+          @create_notices_user_num.push(leads.select(:user_id).distinct)
         end
         # 案件完了予定日を変更時の通知一覧
-        if lead.notice_change_limit == true
-          limit_change_notices.push(lead)
+        if leads.where(notice_change_limit: true).present?
+          @limit_change_notices_total_count += leads.count
+          @limit_change_notices_list.push(leads.where(notice_change_limit: true))
+          @limit_change_notices_user_num.push(leads.select(:user_id).distinct)
         end
       end
-      # create_notices || limit_change_noticesが追加されたら
-      # @memberにユーザー名と追加されたcreate_notices,limit_change_noticesを追加する
-      @member.add(user.name, [create_notices, limit_change_notices])
     end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,28 @@
+class NotificationsController < Users::ApplicationController
+  before_action :set_member
+
+  # 上長視点の通知
+  def notice
+    @member =[]
+    create_notices = []
+    limit_change_notices = []
+    # @usersを通知送信先がcurrent_user.id,statusがactiveのユーザーに絞る
+    users = @users.where(superior_id: current_user.id)
+                  .where(status: "active")
+    users.each do |user|
+      user.leads.each do |lead|
+        # 案件create時の通知一覧
+        if lead.notice_created == true
+          create_notices.push(lead)
+        end
+        # 案件完了予定日を変更時の通知一覧
+        if lead.notice_change_limit == true
+          limit_change_notices.push(lead)
+        end
+      end
+      # create_notices || limit_change_noticesが追加されたら
+      # @memberにユーザー名と追加されたcreate_notices,limit_change_noticesを追加する
+      @member.add(user.name, [create_notices, limit_change_notices])
+    end
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,5 @@
 class NotificationsController < Users::ApplicationController
-  before_action :set_member
+  before_action :set_users
 
   # superior_idに指定されたユーザー視点の通知
   def notice

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :authenticate_scope!, only: %i(edit update)
   prepend_before_action :set_minimum_password_length, only: %i(edit)
-  before_action :set_members, only: %i(edit update)
+  before_action :set_member, only: %i(edit update)
   before_action :only_same_company_id?, only: %i(edit update)
   before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :authenticate_scope!, only: %i(edit update)
   prepend_before_action :set_minimum_password_length, only: %i(edit)
-  before_action :set_member, only: %i(edit update)
+  before_action :set_users, only: %i(edit update)
   before_action :only_same_company_id?, only: %i(edit update)
   before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,9 @@
-class UsersController < Users::ApplicationController
+class UsersController < NotificationsController
   include UsersHelper
 
   # オブジェクトの準備
   before_action :set_user, only: %i(show)
-  before_action :set_members, only: %i(index)
+  before_action :set_member, only: %i(index show)
   # アクセス制限
   before_action :current_user_admin?, only: %i(new create destroy)
 
@@ -27,6 +27,15 @@ class UsersController < Users::ApplicationController
   end
 
   def show
+    # 自分視点の通知
+    # 自分の案件の完了予定日に近づいてる案件の通知
+    @myleads_limit = []
+    myleads = @user.leads.where(status: "in_progress")
+    myleads.each do |lead|
+      if Date.current.to_s > lead.scheduled_contract_date
+        @myleads_limit.push(lead)
+      end
+    end
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < NotificationsController
   # オブジェクトの準備
   before_action :set_user, only: %i(show)
   before_action :set_member, only: %i(index show)
+  before_action :notice, only: :show
   # アクセス制限
   before_action :current_user_admin?, only: %i(new create destroy)
 
@@ -32,7 +33,7 @@ class UsersController < NotificationsController
     @myleads_limit = []
     myleads = @user.leads.where(status: "in_progress")
     myleads.each do |lead|
-      if Date.current.to_s > lead.scheduled_contract_date
+      if Date.current.to_s >= lead.scheduled_contract_date
         @myleads_limit.push(lead)
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,15 +28,9 @@ class UsersController < NotificationsController
   end
 
   def show
-    # 自分視点の通知
     # 自分の案件の完了予定日に近づいてる案件の通知
-    @myleads_limit = []
-    myleads = @user.leads.where(status: "in_progress")
-    myleads.each do |lead|
-      if Date.current.to_s >= lead.scheduled_contract_date
-        @myleads_limit.push(lead)
-      end
-    end
+    limit_date = Date.current + @user.notified_num
+    @myleads_limit_notice = @user.leads.where(status: "in_progress").where("scheduled_contract_date <= ?", limit_date)
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < NotificationsController
 
   # オブジェクトの準備
   before_action :set_user, only: %i(show)
-  before_action :set_member, only: %i(index show)
+  before_action :set_users, only: %i(index show)
   before_action :notice, only: :show
   # アクセス制限
   before_action :current_user_admin?, only: %i(new create destroy)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,8 +29,7 @@ class UsersController < NotificationsController
 
   def show
     # 自分の案件の完了予定日に近づいてる案件の通知
-    limit_date = Date.current + @user.notified_num
-    @myleads_limit_notice = @user.leads.where(status: "in_progress").where("scheduled_contract_date <= ?", limit_date)
+    @myleads_limit_notice = @user.leads.in_progress.where.not(scheduled_contract_date: "").where("scheduled_contract_date <= ?", @user.limit_date)
   end
 
   def destroy

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     return member_list
   end
 
-  # set_memberをbefore_actionしていて引数のusersに@usersを充てる
+  # set_usersをbefore_actionしていて引数のusersに@usersを充てる
   # 引数が上長==trueなら自分以外&&アクティブユーザーを取得、違う場合自分以外&&アクティブな上長の全員を取得する
   def superior_users(users, login_user)
     if login_user.superior?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     return member_list
   end
 
-  # set_membersをbefore_actionしていて引数のusersに@usersを充てる
+  # set_memberをbefore_actionしていて引数のusersに@usersを充てる
   # 引数が上長==trueなら自分以外&&アクティブユーザーを取得、違う場合自分以外&&アクティブな上長の全員を取得する
   def superior_users(users, login_user)
     if login_user.superior?

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,2 @@
+module NotificationsHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,9 @@
 module UsersHelper
+  # ユーザー名を表示するためのメソッド
+  def user_name(id)
+    @users.find(id).name
+  end
+
   # 管理者は削除対象にできない設定+削除対象のユーザーと削除実行ユーザーが同じ企業IDか判定
   def delete_judgment(user)
     user.admin? || user.company_id != current_user.company_id ? false : true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,9 @@ class User < ApplicationRecord
   def users_in_company
     User.where(company_id: self.company_id).order(id)
   end
+
+  # ユーザーが持つ完了してない案件通知の日数と現在日時を計算し通知が発生する日付を返す
+  def limit_date
+    Date.current + self.notified_num
+  end
 end

--- a/app/views/users/_notice.html.erb
+++ b/app/views/users/_notice.html.erb
@@ -1,0 +1,41 @@
+<% if @create_notices_user_num.present? %>
+  <p>
+    登録時通知
+    <%= @create_notices_user_num.count %>人
+    <%= @create_notices_total_count %>件
+  </p>
+  <% @create_notices_list.each do |user_leads| %>
+    <p><%= user_name(user_leads.first.user_id) %></p>
+    <% user_leads.each do |lead| %>
+      <p><%= lead.customer_name %>　<%= lead.created_date %></p>
+    <% end%>
+  <% end %>
+<% end %>
+
+<% if @limit_change_notices_user_num.present? %>
+  <p>
+    変更時通知
+    <%= @limit_change_notices_user_num.count %>人
+    <%= @limit_change_notices_total_count %>件
+  </p>
+  <% @limit_change_notices_list.each do |user_leads| %>
+    <p><%= user_name(user_leads.first.user_id) %></p>
+    <% user_leads.each do |lead| %>
+      <p><%= lead.customer_name %>　<%= lead.scheduled_contract_date %></p>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if @others_limit_notices_user_num.present? %>
+  <p>
+    期限通知
+    <%= @others_limit_notices_user_num.count %>人
+    <%= @others_limit_notices_total_count %>件
+  </p>
+  <% @others_limit_notices_list.each do |user_leads| %>
+    <p><%= user_name(user_leads.first.user_id) %></p>
+    <% user_leads.each do |lead| %>
+      <p><%= lead.customer_name %>　<%= lead.scheduled_contract_date %></p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/_notice.html.erb
+++ b/app/views/users/_notice.html.erb
@@ -8,7 +8,7 @@
     <p><%= user_name(user_leads.first.user_id) %></p>
     <% user_leads.each do |lead| %>
       <p><%= lead.customer_name %>　<%= lead.created_date %></p>
-    <% end%>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,31 +6,16 @@
 <%= link_to "ユーザー新規登録", new_user_path %>
 
 <%= link_to "案件一覧", leads_path %>
-<% if @create_notices_user_num.present? %>
-  <p>
-    登録時通知
-    <%= @create_notices_user_num.count %>人
-    <%= @create_notices_total_count %>件
-  </p>
-  <% @create_notices_list.each do |user_leads| %>
-    <p><%= user_name(user_leads.first.user_id) %></p>
-    <% user_leads.each do |lead| %>
-      <p><%= lead.customer_name %></p>
-    <% end%>
-  <% end %>
-<% end %>
 
-<% if @limit_change_notices_user_num.present? %>
+<%= render "notice" %>
+
+<% if @myleads_limit_notice.present? %>
   <p>
-    変更時通知
-    <%= @limit_change_notices_user_num.count %>人
-    <%= @limit_change_notices_total_count %>件
+    期限間近通知
+    <%= @myleads_limit_notice.count %>件
   </p>
-  <% @limit_change_notices_list.each do |user_leads| %>
-    <p><%= user_name(user_leads.first.user_id) %></p>
-    <% user_leads.each do |lead| %>
-      <p><%= lead.customer_name %></p>
-    <% end %>
+  <% @myleads_limit_notice.each do |lead| %>
+    <p><%= lead.customer_name %>　<%= lead.room_name %>:<%= lead.room_num %>号室　<%= lead.scheduled_contract_date %></p>
   <% end %>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,8 +5,34 @@
 
 <%= link_to "ユーザー新規登録", new_user_path %>
 
-
 <%= link_to "案件一覧", leads_path %>
+<% if @create_notices_user_num.present? %>
+  <p>
+    登録時通知
+    <%= @create_notices_user_num.count %>人
+    <%= @create_notices_total_count %>件
+  </p>
+  <% @create_notices_list.each do |user_leads| %>
+    <p><%= user_name(user_leads.first.user_id) %></p>
+    <% user_leads.each do |lead| %>
+      <p><%= lead.customer_name %></p>
+    <% end%>
+  <% end %>
+<% end %>
+
+<% if @limit_change_notices_user_num.present? %>
+  <p>
+    変更時通知
+    <%= @limit_change_notices_user_num.count %>人
+    <%= @limit_change_notices_total_count %>件
+  </p>
+  <% @limit_change_notices_list.each do |user_leads| %>
+    <p><%= user_name(user_leads.first.user_id) %></p>
+    <% user_leads.each do |lead| %>
+      <p><%= lead.customer_name %></p>
+    <% end %>
+  <% end %>
+<% end %>
 
 <main role="main" class="container">
   <div class="my-3 p-3 bg-white rounded shadow-sm">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,10 +88,10 @@ puts "Userテスト用サンプルレコード作成完了"
       #  memo: "",
       #  status: "進捗中"
       #  notice_created: 新規申込時通知
-        notice_change_limit: true,
+        notice_change_limit: true, # 通知テストの為一時的にtrueに変更してます。
         scheduled_resident_date: (Date.current + 21 - i).to_s,
         scheduled_payment_date: (Date.current + 14 - i).to_s,
-      #  scheduled_contract_date: 契約予定日
+        scheduled_contract_date: Date.current # 通知テストの為一時的にコメントアウト解除してます。
       #  steps_rate: 進捗率
       )
       Step.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,7 +88,7 @@ puts "Userテスト用サンプルレコード作成完了"
       #  memo: "",
       #  status: "進捗中"
       #  notice_created: 新規申込時通知
-      #  notice_change_limit: 期限変更時通知
+        notice_change_limit: true,
         scheduled_resident_date: (Date.current + 21 - i).to_s,
         scheduled_payment_date: (Date.current + 14 - i).to_s,
       #  scheduled_contract_date: 契約予定日
@@ -155,4 +155,3 @@ end
   )
 end
 puts "「SampleUser0」の案件「お客様１」の「進捗１」のタスク作成完了"
-

--- a/spec/requests/notifications_request_spec.rb
+++ b/spec/requests/notifications_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Notifications", type: :request do
+
+end


### PR DESCRIPTION
10/12
登録時通知、完了予定日変更時通知の取得ロジックをpush

10/12 new

- 完了予定日間近の通知を取得ロジックを作成
- 本人、上長で表示を確認しました。

- @usersを使用したメソッド名を変更

## やったこと
10/9 表示テスト実行済み

10/12 本人の〇日前の通知取得日を更新して表示テストを行いました。

## やらないこと
viewについてeachで表示確認を行うに留めてます。

## できるようになること(ユーザ目線)
通知を自分のusers#showページで自分の案件通知を取得、
上長は自分の案件プラス他の人から通知先に指定されてる場合に取得される。
## できなくなること(ユーザ目線)
特になし
## 動作確認

- 上長、一般ユーザーにわけてログインし、表示確認

- 〇日前の通知取得日を更新させて通知を取得できるか手動確認

## その他
10/12 new
今までのプルリクで上がっていたコメントに対応し、完了予定日間近の通知を取得できるロジックをpushしました。
マージされた次は上がっている通知を確認する(通知カラムをfalse変更させる)ロジックを作成する予定です。

