### PR TITLE
Embed form and finish button 2

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -6,6 +6,7 @@
 
 .label-task--new {
   margin-top: 5px;
+  font-size: small;
 }
 
 .btn-task--new {

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -2,7 +2,10 @@ class Leads::ApplicationController < Users::ApplicationController
   include LeadsHelper
   
   # 進捗の開始処理を実行し詳細ページへ遷移
-  def start_step(lead, step)
+  def start_step(lead, step, new_task)
+    if new_task == "true"
+      Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
+    end
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
         scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -3,11 +3,11 @@ class Leads::ApplicationController < Users::ApplicationController
   
   # 進捗の開始処理を実行し詳細ページへ遷移
   def start_step(lead, step, new_task)
-    if new_task == "true"
-      Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
-    end
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
+        if new_task == "true"
+          Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
+        end
         scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
         case step.status
         when "not_yet"

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -191,7 +191,7 @@ class Leads::ApplicationController < Users::ApplicationController
       tasks_edit_complete_or_continue_step_step_url(@step)
 
     #進捗に「未」のタスクがあるにも関わらず、進捗のstatusが「完了」の場合、change_status_or_complete_taskのurlにリダイレクトする
-    elsif @step.tasks.find_by(status: "not_yet").present? && @step.status == "completed"
+    elsif @step.tasks.find_by(status: "not_yet").present? && @step.status?("completed")
       tasks_edit_change_status_or_complete_task_step_url(@step)
 
     #以上いずれでもない場合、steps#showにリダイレクトする

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -2,23 +2,27 @@ class Leads::ApplicationController < Users::ApplicationController
   include LeadsHelper
   
   # 進捗の開始処理を実行し詳細ページへ遷移
-  def start_step(lead, step, new_task)
+  def start_step(lead, step)
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
-        if new_task == "true"
-          Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
-        end
-        scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
-        case step.status
-        when "not_yet"
-          @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date)
-        when "inactive"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, canceled_date: "")
-        when "in_progress"
-          @success_message = "#{step.name}は既に進捗中です。"
-        when "completed"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "")
-        end
+      #if new_task == "true"
+      #  Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
+      #end
+      scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
+      case step.status
+      when "not_yet"
+        @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date)
+      when "inactive"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, canceled_date: "")
+      when "in_progress"
+        @success_message = "#{step.name}は既に進捗中です。"
+      when "completed"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "")
+      end
+
+      if params[:new_task].present?
+        Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}") if params[:new_task] == "true"
+      end
        
       if params[:completed_id].present?
         completed_step = Step.find(params[:completed_id])

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -67,6 +67,7 @@ class Leads::ApplicationController < Users::ApplicationController
       raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status)
     end
     if lead.errors.blank?
+      sort_order
       flash[:success] = "#{step.name}を削除しました。"
       redirect_to working_step_in(lead)
     else
@@ -159,5 +160,18 @@ class Leads::ApplicationController < Users::ApplicationController
   def calculate_rate(completed_num, not_yet_num)
     return completed_num == 0 ? 0 : 100 * completed_num / (completed_num + not_yet_num)
   end
-  
+ 
+  # 順番をチェックし、空があったら詰める処理
+  def sort_order
+    if @lead.steps.find_by(order: @lead.steps.count + 1).present?
+      (1..@lead.steps.count).each do |order_num|
+        if @lead.steps.find_by(order: order_num).blank?
+          step = @lead.steps.find_by(order: order_num + 1)
+          step.update_attribute(:order, order_num)
+        end
+      end
+    end
+  end
+ 
+ 
 end

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -176,8 +176,30 @@ class Leads::ApplicationController < Users::ApplicationController
       end
     end
   end
-  
-  
+
+  # タスクの状態に応じてリダイレクト先を取得する
+  def check_status_and_get_url  
+    # タスク操作後、
+
+    # 進捗に「未」のタスクが無く、かつ「完了」のタスクも無い場合、continue_or_destroy_stepのurlにリダイレクトする
+    if @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").nil?
+      tasks_edit_continue_or_destroy_step_step_url(@step)
+      #redirect_to tasks_edit_continue_or_destroy_step_step_url(@step, format: "js")
+
+    #進捗に「未」のタスクが無く、かつ「完了」のタスクが１つ以上ある場合、complete_or_continue_stepのurlにリダイレクトする
+    elsif @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").present?
+      tasks_edit_complete_or_continue_step_step_url(@step)
+
+    #進捗に「未」のタスクがあるにも関わらず、進捗のstatusが「完了」の場合、change_status_or_complete_taskのurlにリダイレクトする
+    elsif @step.tasks.find_by(status: "not_yet").present? && @step.status == "completed"
+      tasks_edit_change_status_or_complete_task_step_url(@step)
+
+    #以上いずれでもない場合、steps#showにリダイレクトする
+    else
+      step_url(@step)
+    end 
+  end
+
   private
     # 進捗一覧を取得
     def set_steps

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -5,9 +5,9 @@ class Leads::ApplicationController < Users::ApplicationController
   def start_step(lead, step)
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
-      #if new_task == "true"
-      #  Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
-      #end
+      if params[:new_task].present?
+        Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}") if params[:new_task] == "true"
+      end
       scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
       case step.status
       when "not_yet"
@@ -19,11 +19,7 @@ class Leads::ApplicationController < Users::ApplicationController
       when "completed"
         @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "")
       end
-
-      if params[:new_task].present?
-        Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}") if params[:new_task] == "true"
-      end
-       
+      
       if params[:completed_id].present?
         completed_step = Step.find(params[:completed_id])
         @success_message = "#{flash[:success]}#{step.name}を開始しました。" if complete_step(lead, completed_step, completed_step.latest_date)
@@ -187,16 +183,15 @@ class Leads::ApplicationController < Users::ApplicationController
 
     # 進捗に「未」のタスクが無く、かつ「完了」のタスクも無い場合、continue_or_destroy_stepのurlにリダイレクトする
     if @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").nil?
-      tasks_edit_continue_or_destroy_step_step_url(@step)
-      #redirect_to tasks_edit_continue_or_destroy_step_step_url(@step, format: "js")
+      edit_continue_or_destroy_step_task_url(@step)
 
     #進捗に「未」のタスクが無く、かつ「完了」のタスクが１つ以上ある場合、complete_or_continue_stepのurlにリダイレクトする
     elsif @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").present?
-      tasks_edit_complete_or_continue_step_step_url(@step)
+      edit_complete_or_continue_step_task_url(@step)
 
     #進捗に「未」のタスクがあるにも関わらず、進捗のstatusが「完了」の場合、change_status_or_complete_taskのurlにリダイレクトする
     elsif @step.tasks.find_by(status: "not_yet").present? && @step.status?("completed")
-      tasks_edit_change_status_or_complete_task_step_url(@step)
+      edit_change_status_or_complete_task_task_url(@step)
 
     #以上いずれでもない場合、steps#showにリダイレクトする
     else

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -72,6 +72,10 @@ class Leads::StepsController < Leads::ApplicationController
     destroy_step(@lead, @step)
   end
 
+  def or_destroy_step
+    destroy_step(@lead, @step)
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_step

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -72,7 +72,7 @@ class Leads::StepsController < Leads::ApplicationController
     destroy_step(@lead, @step)
   end
 
-  def or_destroy_step
+  def statuses_destroy_step
     destroy_step(@lead, @step)
   end
 

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -94,8 +94,8 @@ class Leads::StepsController < Leads::ApplicationController
     cancel_step(@lead, @step)
   end
 
-  # すべてのタスクを未にする
-  def statuses_make_all_tasks_not_yet
+  # 「未」のタスクをすべて「完了」とする
+  def statuses_make_all_not_yet_tasks_completed
     #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
     errors = []
     ActiveRecord::Base.transaction do

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -72,11 +72,6 @@ class Leads::StepsController < Leads::ApplicationController
     destroy_step(@lead, @step)
   end
 
-  # 進捗を削除する
-  def statuses_destroy_step
-    destroy_step(@lead, @step)
-  end
-
   # 進捗を未にする
   def statuses_make_step_not_yet
     errors = []
@@ -84,23 +79,6 @@ class Leads::StepsController < Leads::ApplicationController
       errors << @step.errors.full_messages unless @step.update_attributes(status: "not_yet")
       update_steps_rate(@lead)
       errors << @lead.errors.full_messages if @lead.invalid?(:check_steps_status)
-      raise ActiveRecord::Rollback if errors.present?
-    end
-    redirect_to check_status_and_get_url
-  end
-
-  # 進捗を保留にする
-  def statuses_make_step_inactive
-    cancel_step(@lead, @step)
-  end
-
-  # 「未」のタスクをすべて「完了」とする
-  def statuses_make_all_not_yet_tasks_completed
-    #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
-    errors = []
-    ActiveRecord::Base.transaction do
-      errors << @step.errors.full_messages unless @step.tasks.not_yet.update_all(status: "completed", completed_date: "#{Date.current}")
-      update_completed_tasks_rate(@step)
       raise ActiveRecord::Rollback if errors.present?
     end
     redirect_to check_status_and_get_url

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -97,7 +97,7 @@ class Leads::StepsController < Leads::ApplicationController
   # すべてのタスクを未にする
   def statuses_make_all_tasks_not_yet
     #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
-    @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: "#{Date.current}")
+    @step.tasks.not_yet.update_all(status: "completed", completed_date: "#{Date.current}")
     update_completed_tasks_rate(@step)
     redirect_to check_status_and_get_url
   end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -72,8 +72,34 @@ class Leads::StepsController < Leads::ApplicationController
     destroy_step(@lead, @step)
   end
 
+  # 進捗を削除する
   def statuses_destroy_step
     destroy_step(@lead, @step)
+  end
+
+  # 進捗を未にする
+  def statuses_make_step_not_yet
+    if @step.update_attributes(status: "not_yet")
+      update_steps_rate(@lead)
+      redirect_to check_status_and_get_url
+    else
+      flash[:danger] = @step.errors.full_messages.first
+      #render :edit_change_status_or_complete_task
+      redirect_to check_status_and_get_url
+    end
+  end
+
+  # 進捗を保留にする
+  def statuses_make_step_inactive
+    cancel_step(@lead, @step)
+  end
+
+  # すべてのタスクを未にする
+  def statuses_make_all_tasks_not_yet
+    #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
+    @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: "#{Date.current}")
+    update_completed_tasks_rate(@step)
+    redirect_to check_status_and_get_url
   end
 
   private

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -6,7 +6,7 @@ class Leads::StepsController < Leads::ApplicationController
   before_action :only_same_company_id?
   before_action :correct_user, except: %i(index show)
   # 後処理
-  after_action :sort_order, only: %i(destroy index)
+  # after_action :sort_order, only: %i(destroy index)
 
 
   # GET /steps
@@ -151,18 +151,6 @@ class Leads::StepsController < Leads::ApplicationController
           (new_order..(pre_order - 1)).reverse_each do |order_num|
             next_step = @lead.steps.find_by(order: order_num)
             next_step.update_attribute(:order, order_num + 1)
-          end
-        end
-      end
-    end
-    
-    # 順番をチェックし、空があったら詰める処理
-    def sort_order
-      if @lead.steps.find_by(order: @lead.steps.count + 1).present?
-        (1..@lead.steps.count).each do |order_num|
-          if @lead.steps.find_by(order: order_num).blank?
-            step = @lead.steps.find_by(order: order_num + 1)
-            step.update_attribute(:order, order_num)
           end
         end
       end

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -20,7 +20,10 @@ class Leads::StepsStatusesController < Leads::StepsController
   end
   
   def start
-    start_step(@lead, @step)
+    if [:step].present?
+      new_task = params[:step][:new_task]
+      start_step(@lead, @step, new_task)
+    end
   end
   
   def cancel

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -20,10 +20,7 @@ class Leads::StepsStatusesController < Leads::StepsController
   end
   
   def start
-    if [:step].present?
-      new_task = params[:step][:new_task]
-      start_step(@lead, @step, new_task)
-    end
+    start_step(@lead, @step)
   end
   
   def cancel

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -5,6 +5,7 @@ class Leads::TasksController < Leads::ApplicationController
   before_action :set_step, only: %i(index new create)
   before_action :set_step_by_id, only: [:edit_add_delete_list, :update_add_delete_list, :edit_continue_or_destroy_step, :update_continue_or_destroy_step,
                                         :edit_complete_or_continue_step, :update_complete_or_continue_step, :edit_change_status_or_complete_task, :update_change_status_or_complete_task]
+  before_action :set_steps, only: :edit_complete_or_continue_step
   # アクセス制限
   before_action :correct_user, except: %i(index show)
   #after_action :sort_order, :update_continue_or_destroy_step

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -235,29 +235,6 @@ class Leads::TasksController < Leads::ApplicationController
       day.blank? ? false : Date.parse(day) < Date.current
     end
 
-
-    def check_status_and_get_url
-      # タスク操作後、
-      
-      # 進捗に「未」のタスクが無く、かつ「完了」のタスクも無い場合、continue_or_destroy_stepのurlにリダイレクトする
-      if @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").nil?
-        tasks_edit_continue_or_destroy_step_step_url(@step)
-        #redirect_to tasks_edit_continue_or_destroy_step_step_url(@step, format: "js")
-
-      #進捗に「未」のタスクが無く、かつ「完了」のタスクが１つ以上ある場合、complete_or_continue_stepのurlにリダイレクトする
-      elsif @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").present?
-        tasks_edit_complete_or_continue_step_step_url(@step)
-
-      #進捗に「未」のタスクがあるにも関わらず、進捗のstatusが「完了」の場合、change_status_or_complete_taskのurlにリダイレクトする
-      elsif @step.tasks.find_by(status: "not_yet").present? && @step.status == "completed"
-        tasks_edit_change_status_or_complete_task_step_url(@step)
-      
-      #以上いずれでもない場合、steps#showにリダイレクトする
-      else
-        step_url(@step)
-      end 
-    end
-
     def create_new_task_step_in_progress(lead, step)
       Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
       redirect_to step_statuses_start_step_url(@step)

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -7,6 +7,7 @@ class Leads::TasksController < Leads::ApplicationController
                                         :edit_complete_or_continue_step, :update_complete_or_continue_step, :edit_change_status_or_complete_task, :update_change_status_or_complete_task]
   # アクセス制限
   before_action :correct_user, except: %i(index show)
+  #after_action :sort_order, :update_continue_or_destroy_step
 
   
 

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -15,11 +15,11 @@ class Leads::TasksController < Leads::ApplicationController
 
   def index
     # タスクステータスが「未」のリスト
-    @tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date)
+    @tasks = @step.tasks.not_yet.order(:scheduled_complete_date)
     # タスクステータスが「完了」のリスト
-    @completed_tasks_array = @step.tasks.where(status: "completed").order(:completed_date)
+    @completed_tasks_array = @step.tasks.completed.order(:completed_date)
     # タスクステータスが「中止」のリスト
-    @canceled_tasks_array = @step.tasks.where(status: "canceled").order(:canceled_date)
+    @canceled_tasks_array = @step.tasks.canceled.order(:canceled_date)
     @task = @step.tasks.new
   end
 
@@ -89,13 +89,13 @@ class Leads::TasksController < Leads::ApplicationController
     n1 = checkbox_array.size
     i2 = 0
     # タスクステータスが「完了」のリスト
-    @completed_tasks_array = @step.tasks.where(status: "completed").order(:completed_date)
+    @completed_tasks_array = @step.tasks.completed.order(:completed_date)
 
     n1.times do |i1|
       if checkbox_array[i1] == "true"
         # (i1-i2)番目のタスクステータスが「未」のタスクの１個の要素からなるActiveRecordAsociation?Relationがdeleted_tasks(配列のようなもの)
         # 下でタスクステータスを「未」から「完了」に変えているのでi2(checkbox=="true"の数)だけi1から引いている
-        deleted_tasks = @step.tasks.where(status: "not_yet").order(:scheduled_complete_date).limit(1).offset(i1 - i2)
+        deleted_tasks = @step.tasks.not_yet.order(:scheduled_complete_date).limit(1).offset(i1 - i2)
         i2 += 1
         # 1個の要素からなるActiveRecordAsociation?Relationから1個の要素deleted_taskを取り出して
         # タスクステータスを「完了」、「完了日」を本日に設定している
@@ -157,7 +157,7 @@ class Leads::TasksController < Leads::ApplicationController
     # 進捗を完了を選択したとき
     if params[:complete_or_continue] == "completed"
       #stautsが「完了」のタスクの中でもっとも遅い「完了日」をこの進捗の完了日とし、現在の進捗を「完了」とする
-      latest_date = @step.tasks.where(status: "completed").maximum(:completed_date)
+      latest_date = @step.tasks.completed.maximum(:completed_date)
       #redirect_to step_statuses_complete_step_url(@step, latest_date) and return
       complete_step(@lead, @step, latest_date)
       # steps#showにリダイレクト
@@ -197,7 +197,7 @@ class Leads::TasksController < Leads::ApplicationController
     #「未」のタスクをすべて「完了」を選択したとき
     else
       #現在の進捗の「未」のタスクをすべて「完了」とし、「完了日」を本日とし、その後complete_or_continueのurlへ飛ぶ
-      @step.tasks.where(status: "not_yet").update_all(status: "completed", completed_date: "#{Date.current}")
+      @step.tasks.not_yet.update_all(status: "completed", completed_date: "#{Date.current}")
       update_completed_tasks_rate(@step)
       redirect_to check_status_and_get_url
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,15 +3,9 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { in: 0..60 }
   validates :memo, length: { in: 0..400 }
   validates :scheduled_complete_date, presence: true
+  validate :completed_date_prohibit_future # 完了日に現在の日付より未来の日付を入れる場合はアラート
   enum status: [:not_yet, :completed, :canceled] # 進捗ステータス
   
-  # 完了日に現在の日付より未来の日付を入れる場合はアラート
-  validate :not_newer_than_today
-
-  def not_newer_than_today
-    errors.add(:completed_date, "は未来の日付は入れられません") if completed_date.present? && Date.parse(completed_date) > Date.current
-  end
-
   # 完了日または中止にした日が空なら今日の日付を入れる
   def date_blank_then_today(status)
     if status == "completed"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,13 +8,13 @@ class Task < ApplicationRecord
   
   # 完了日または中止にした日が空なら今日の日付を入れる
   def date_blank_then_today(status)
-    if status == "completed"
-      if self.status == "completed" && self.completed_date.blank?
-        self.update_attribute(:completed_date, (I18n.l Date.current))
+    if self.status?("completed")
+      if self.status?("completed") && self.completed_date.blank?
+        self.update_attribute(:completed_date, "#{Date.current}")
       end
-    elsif status == "canceled"
-      if self.status == "canceled" && self.canceled_date.blank?
-        self.update_attribute(:canceled_date, (I18n.l Date.current))
+    elsif self.status?("canceled")
+      if self.status?("canceled") && self.canceled_date.blank?
+        self.update_attribute(:canceled_date, "#{Date.current}")
       end
     end
   end

--- a/app/views/leads/step_statuses/_complete.html.erb
+++ b/app/views/leads/step_statuses/_complete.html.erb
@@ -19,7 +19,7 @@
               <tr>
                 <td>Step<%= step.order %></td>
                 <% if step.status?("not_yet") %>
-                  <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を設定して開始する" %></td>
+                  <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, new_task: nil, button_name: "完了予定日を設定して開始する" %></td>
                 <% elsif step.status?("inactive") %>
                   <td>
                     <p>
@@ -29,7 +29,7 @@
                     </p>
                     <div id="collapseStep<%= step.id %>" class="collapse">
                     	<div class="well">
-                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を再設定して再開する" %>
+                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, new_task: nil, button_name: "完了予定日を再設定して再開する" %>
                     	</div>
                     </div>
                   </td>
@@ -44,7 +44,7 @@
                     </p>
                     <div id="collapseStep<%= step.id %>" class="collapse">
                     	<div class="well">
-                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を再設定して再開する" %>
+                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, new_task: nil, button_name: "完了予定日を再設定して再開する" %>
                     	</div>
                     </div>
                   </td>

--- a/app/views/leads/step_statuses/_start.html.erb
+++ b/app/views/leads/step_statuses/_start.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(url: start_step_path(step, completed_id: completed_id, new_task: new_task), model: step, local: true) do |form| %>
   <%= form.label :scheduled_complete_date %>
   <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %>
-  <%= form.hidden_field :new_task, value:  new_task %>
+  <%= form.hidden_field :new_task, value: new_task %>
   <%= form.submit button_name, class: "btn btn-primary" %>
 <% end %>

--- a/app/views/leads/step_statuses/_start.html.erb
+++ b/app/views/leads/step_statuses/_start.html.erb
@@ -1,6 +1,6 @@
-<%= form_with(url: start_step_path(step, completed_id: completed_id), model: step, local: true, new_task: new_task) do |form| %>
+<%= form_with(url: start_step_path(step, completed_id: completed_id, new_task: new_task), model: step, local: true) do |form| %>
   <%= form.label :scheduled_complete_date %>
   <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %>
-  <%= form.hidden_field :new_task, :value => new_task %>
+  <%= form.hidden_field :new_task, value:  new_task %>
   <%= form.submit button_name, class: "btn btn-primary" %>
 <% end %>

--- a/app/views/leads/step_statuses/_start.html.erb
+++ b/app/views/leads/step_statuses/_start.html.erb
@@ -1,5 +1,6 @@
-<%= form_with(url: start_step_path(step, completed_id: completed_id), model: step, local: true) do |form| %>
+<%= form_with(url: start_step_path(step, completed_id: completed_id), model: step, local: true, new_task: new_task) do |form| %>
   <%= form.label :scheduled_complete_date %>
   <%= form.date_field :scheduled_complete_date, value: step.scheduled_complete_date %>
+  <%= form.hidden_field :new_task, :value => new_task %>
   <%= form.submit button_name, class: "btn btn-primary" %>
 <% end %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -88,14 +88,14 @@
     <h5 style="display:inline;">
       <% case @step.status %>
       <% when "not_yet" %>
-        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
       <% when "inactive" %>
-        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
       <% when "in_progress" %>
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
         <%= render 'leads/step_statuses/cancel', step: @step, button_name: "保留" %>
       <% when "completed" %>
-        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
       <% when "template" %>
         <button type="button" class="btn btn-info">このテンプレートを使用して新規作成</button>
       <% end %>

--- a/app/views/leads/steps/step_statuses_complete.html.erb
+++ b/app/views/leads/steps/step_statuses_complete.html.erb
@@ -1,2 +1,0 @@
-<button type="button" class="btn btn-info" data-toggle="modal" data-target="#step-complete" data-name="<%= @step.name %>" data-id="<%= @step.id %>">完了</button>
-

--- a/app/views/leads/steps/step_statuses_start.html.erb
+++ b/app/views/leads/steps/step_statuses_start.html.erb
@@ -1,1 +1,0 @@
-<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>

--- a/app/views/leads/steps/step_statuses_start.html.erb
+++ b/app/views/leads/steps/step_statuses_start.html.erb
@@ -1,1 +1,1 @@
-<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
+<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>

--- a/app/views/leads/tasks/_tasks_index.html.erb
+++ b/app/views/leads/tasks/_tasks_index.html.erb
@@ -1,7 +1,11 @@
 <% provide(:class_text, 'task--new') %>
 <% provide(:button_text, '作成') %>
-<p>タスク一覧 </p>
-<p>To Do リスト</p>
+<h3>タスク一覧 </h3>
+
+<h4 style="display:inline;"><%= "To Do リスト"%></h4><h5 style="display:inline;"><%= "<STEP#{@step.order}>完了まであと#{@tasks.count}件" %></h5>
+<br>
+<br>
+
 <table>
   <tbody>
     <%= form_with(model: @tasks, url: tasks_update_add_delete_list_step_path(@step), local: true, mothod: :post) do |f| %>
@@ -60,7 +64,8 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <p class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapse3">済 リスト</a>
+        <a data-toggle="collapse" data-parent="#accordion" href="#collapse3"><h4 style="display:inline;"><%= "済 リスト" %></h4></a>
+        <h5 style="display:inline;"><%= "(#{@completed_tasks_array.count}件)" %></h5>
       </p>
     </div>
     <div id="collapse3" class="panel-collapse collapse in">
@@ -83,7 +88,8 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <p class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4">中止 リスト</a>
+        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4"><h4 style="display:inline;"><%= "中止 リスト" %></h4></a>
+        <h5 style="display:inline;"><%= "(#{@canceled_tasks_array.count}件)" %></h5>
       </p>
     </div>
     <div id="collapse4" class="panel-collapse collapse">

--- a/app/views/leads/tasks/_tasks_index.html.erb
+++ b/app/views/leads/tasks/_tasks_index.html.erb
@@ -2,13 +2,13 @@
 <% provide(:button_text, '作成') %>
 <h3>タスク一覧 </h3>
 
-<h4 style="display:inline;"><%= "To Do リスト"%></h4><h5 style="display:inline;"><%= "<STEP#{@step.order}>完了まであと#{@tasks.count}件" %></h5>
+<h4 style="display:inline;">To Do リスト</h4><h5 style="display:inline;"><%= "<STEP#{@step.order}>完了まであと#{@tasks.count}件" %></h5>
 <br>
 <br>
 
 <table>
   <tbody>
-    <%= form_with(model: @tasks, url: tasks_update_add_delete_list_step_path(@step), local: true, mothod: :post) do |f| %>
+    <%= form_with(model: @tasks, url: update_add_delete_list_task_path(@step), local: true, mothod: :post) do |f| %>
       <% @tasks.each do |task| %>
         <tr>
           <td><%= f.check_box(:delete_task, { multiple: true, class: "check_box"}, checked_value = "true", unchecked_value = "false") %></td>
@@ -64,7 +64,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <p class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapse3"><h4 style="display:inline;"><%= "済 リスト" %></h4></a>
+        <a data-toggle="collapse" data-parent="#accordion" href="#collapse3"><h4 style="display:inline;">済 リスト</h4></a>
         <h5 style="display:inline;"><%= "(#{@completed_tasks_array.count}件)" %></h5>
       </p>
     </div>
@@ -88,7 +88,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <p class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4"><h4 style="display:inline;"><%= "中止 リスト" %></h4></a>
+        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4"><h4 style="display:inline;">中止 リスト</h4></a>
         <h5 style="display:inline;"><%= "(#{@canceled_tasks_array.count}件)" %></h5>
       </p>
     </div>

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,12 +1,12 @@
 <h4>&#9312現在の進捗を「未」にする</h4>
-  <%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :get %>
+<%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :get %>
 <br>
 <h4>&#9313現在の進捗を「進捗中」にする</h4>
-  <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
+<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
 <br>
 <h4>&#9314現在の進捗を「保留」にする</h4>
-  <%= button_to '更新', statuses_make_step_inactive_step_path(@step), method: :get %>
+<%= button_to '更新', cancel_step_path(@step), method: :patch %>
 <br>
 <h4>&#9315「未」のタスクをすべて「完了」にする</h4>
-  <%= button_to '更新', statuses_make_all_tasks_not_yet_step_path(@step), method: :get %>
+<%= button_to '更新', statuses_make_all_not_yet_tasks_completed_step_path(@step), method: :get %>
 ~  

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,21 +1,12 @@
-<% provide(:class_text, 'task--edit_change_status_or_complete_task') %>
-<% provide(:button_text, '選択') %>
-
-<h3>いづれか選択してください </h3>
-
-<%= form_with(url: tasks_update_change_status_or_complete_task_step_path(step_id: @step), method: :post, local: true) do |f| %>
-
-  <%= f.radio_button :change_status_or_complete_task, :not_yet , checked: 'checked' %>
-  <%= f.label :change_status_or_complete_task, "現在の進捗を「未」にする", value: :not_yet %>
-  <br>
-  <%= f.radio_button :change_status_or_complete_task, :in_progress %>
-  <%= f.label :change_status_or_complete_task, "現在の進捗を「進捗中」にする", value: :in_progress %>
-  <br>
-  <%= f.radio_button :change_status_or_complete_task, :inactive %>
-  <%= f.label :change_status_or_complete_task, "現在の進捗を「保留」にする", value: :inactive %>
-  <br>
-  <%= f.radio_button :change_status_or_complete_task, :erase_all_not_yet %>
-  <%= f.label :change_status_or_complete_task, "「未」のタスクをすべて「完了」にする", value: :erase_all_not_yet %>
-  <br>
-　<%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
-<% end %>
+<h4>&#9312現在の進捗を「未」にする</h4>
+  <%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :get %>
+<br>
+<h4>&#9313現在の進捗を「進捗中」にする</h4>
+  <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
+<br>
+<h4>&#9314現在の進捗を「保留」にする</h4>
+  <%= button_to '更新', statuses_make_step_inactive_step_path(@step), method: :get %>
+<br>
+<h4>&#9315「未」のタスクをすべて「完了」にする</h4>
+  <%= button_to '更新', statuses_make_all_tasks_not_yet_step_path(@step), method: :get %>
+~  

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,12 +1,12 @@
-<h4>&#9312現在の進捗を「未」にする</h4>
-<%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :get %>
+<h4>&#9312;現在の進捗を「未」にする</h4>
+<%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :patch %>
 <br>
-<h4>&#9313現在の進捗を「進捗中」にする</h4>
+<h4>&#9313;現在の進捗を「進捗中」にする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
 <br>
-<h4>&#9314現在の進捗を「保留」にする</h4>
+<h4>&#9314;現在の進捗を「保留」にする</h4>
 <%= button_to '更新', cancel_step_path(@step), method: :patch %>
 <br>
-<h4>&#9315「未」のタスクをすべて「完了」にする</h4>
-<%= button_to '更新', statuses_make_all_not_yet_tasks_completed_step_path(@step), method: :get %>
+<h4>&#9315;「未」のタスクをすべて「完了」にする</h4>
+<%= button_to '更新', statuses_make_all_not_yet_tasks_completed_task_path(@step), method: :patch %>
 ~  

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,5 +1,5 @@
-<h4>&#9312「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
+<h4>&#9312;「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
 <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
 <br>
-<h4>&#9313この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
+<h4>&#9313;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,16 +1,5 @@
-<% provide(:class_text, 'task--edit_complete_or_continue_step') %>
-<% provide(:button_text, '選択') %>
-
-<h3>どちらか選択してください </h3>
-
-<%= form_with(url: tasks_update_complete_or_continue_step_step_path(step_id: @step), method: :post, local: true) do |f| %>
-
-  <%= f.radio_button :complete_or_continue, :completed , checked: 'checked' %>
-  <%= f.label :complete_or_continue, "「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする", value: :completed %>
-  <br>
-  <%= f.radio_button :complete_or_continue, :continue %>
-  <%= f.label :complete_or_continue, "この進捗にタスクを追加し、現在の進捗を「進捗中」とする", value: :continue %>
-  <br>
-　<%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
-<% end %>
-
+<h4>&#9312「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
+  <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
+<br>
+<h4>&#9313この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
+ <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,5 +1,5 @@
 <h4>&#9312「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
-  <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
+<%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
 <br>
 <h4>&#9313この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
- <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
+<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,12 +1,23 @@
 <% provide(:class_text, 'task--edit_continue_or_destroy_step') %>
 <% provide(:button_text, '選択') %>
+<% provide(:class_text, 'task--edit_continue_or_destroy_step') %>
+<% provide(:button_text, '選択') %>
+
 <p>この進捗にタスクを追加し、現在の進捗を「進捗中」とする</p>
+ <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
 
 
 
+<h3>どちらか選択してください </h3>
 
-<p>この進捗を削除する</p>   
-
-
-
+<%= form_with(url: tasks_update_continue_or_destroy_step_step_path(step_id: @step), method: :post, local: true) do |f| %>
+        
+  <%= f.radio_button :continue_or_destroy, :continue , checked: 'checked' %>
+  <%= f.label :continue_or_destroy, "この進捗にタスクを追加し、現在の進捗を「進捗中」とする", value: :continue %>
+  <br>
+  <%= f.radio_button :continue_or_destroy, :destroy %>
+  <%= f.label :continue_or_destroy, "この進捗を削除する", value: :destroy %>
+  <br>
+　<%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
+<% end %>
 

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,6 +1,6 @@
-<h4>&#9312この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
+<h4>&#9312;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
 <br>
-<h4>&#9313この進捗を削除する</h4>
+<h4>&#9313;この進捗を削除する</h4>
 <%= button_to '削除', step_path(@step), method: :delete %>
 

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,8 +1,6 @@
-<% provide(:class_text, 'task--edit_continue_or_destroy_step') %>
-<% provide(:button_text, '選択') %>
-
-<h4>この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
+<h4>&#9312この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
  <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
-<h4>この進捗を削除する</h4>
- <%= button_to '削除', or_destroy_step_step_path(@step), method: :get %>
+<br>
+<h4>&#9313この進捗を削除する</h4>
+ <%= button_to '削除', statuses_destroy_step_step_path(@step), method: :get %>
 

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,23 +1,8 @@
 <% provide(:class_text, 'task--edit_continue_or_destroy_step') %>
 <% provide(:button_text, '選択') %>
-<% provide(:class_text, 'task--edit_continue_or_destroy_step') %>
-<% provide(:button_text, '選択') %>
 
-<p>この進捗にタスクを追加し、現在の進捗を「進捗中」とする</p>
+<h4>この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
  <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
-
-
-
-<h3>どちらか選択してください </h3>
-
-<%= form_with(url: tasks_update_continue_or_destroy_step_step_path(step_id: @step), method: :post, local: true) do |f| %>
-        
-  <%= f.radio_button :continue_or_destroy, :continue , checked: 'checked' %>
-  <%= f.label :continue_or_destroy, "この進捗にタスクを追加し、現在の進捗を「進捗中」とする", value: :continue %>
-  <br>
-  <%= f.radio_button :continue_or_destroy, :destroy %>
-  <%= f.label :continue_or_destroy, "この進捗を削除する", value: :destroy %>
-  <br>
-　<%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
-<% end %>
+<h4>この進捗を削除する</h4>
+ <%= button_to '削除', or_destroy_step_step_path(@step), method: :get %>
 

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,6 +1,6 @@
 <h4>&#9312この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
- <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
+<%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
 <br>
 <h4>&#9313この進捗を削除する</h4>
- <%= button_to '削除', statuses_destroy_step_step_path(@step), method: :get %>
+<%= button_to '削除', step_path(@step), method: :delete %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
         get 'step_statuses_start'
         get 'step_statuses_complete'
-        get 'or_destroy_step'
+        get 'statuses_destroy_step'
       end
       member do
         get 'tasks/edit_add_delete_list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
         get 'step_statuses_start'
         get 'step_statuses_complete'
+        get 'or_destroy_step'
       end
       member do
         get 'tasks/edit_add_delete_list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
         get 'step_statuses_start'
         get 'step_statuses_complete'
         get 'statuses_destroy_step'
+        get 'statuses_make_step_not_yet'
+        get 'statuses_make_step_inactive'
+        get 'statuses_make_all_tasks_not_yet'
       end
       member do
         get 'tasks/edit_add_delete_list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,8 @@ Rails.application.routes.draw do
         patch 'complete/:completed_id' => 'steps_statuses#complete', as: :complete
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
-        get 'statuses_destroy_step'
         get 'statuses_make_step_not_yet'
-        get 'statuses_make_step_inactive'
-        get 'statuses_make_all_tasks_not_yet'
+        get 'statuses_make_all_not_yet_tasks_completed'
       end
       member do
         get 'tasks/edit_add_delete_list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,21 +26,20 @@ Rails.application.routes.draw do
         patch 'complete/:completed_id' => 'steps_statuses#complete', as: :complete
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
-        get 'statuses_make_step_not_yet'
-        get 'statuses_make_all_not_yet_tasks_completed'
-      end
-      member do
-        get 'tasks/edit_add_delete_list'
-        post 'tasks/update_add_delete_list'
-        get 'tasks/edit_continue_or_destroy_step'
-        get 'tasks/edit_complete_or_continue_step'
-        get 'tasks/edit_change_status_or_complete_task'
+        patch 'statuses_make_step_not_yet'
+       # patch 'statuses_make_all_not_yet_tasks_completed'
       end
       resources :tasks do
         member do
           get 'add_canceled_list'
           get 'edit_revive_from_canceled_list'
           patch 'update_revive_from_canceled_list'
+          get 'edit_add_delete_list'
+          post 'update_add_delete_list'
+          get 'edit_continue_or_destroy_step'
+          get 'edit_complete_or_continue_step'
+          get 'edit_change_status_or_complete_task'
+          patch 'statuses_make_all_not_yet_tasks_completed'
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,8 +26,6 @@ Rails.application.routes.draw do
         patch 'complete/:completed_id' => 'steps_statuses#complete', as: :complete
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
-        get 'step_statuses_start'
-        get 'step_statuses_complete'
         get 'statuses_destroy_step'
         get 'statuses_make_step_not_yet'
         get 'statuses_make_step_inactive'
@@ -37,11 +35,8 @@ Rails.application.routes.draw do
         get 'tasks/edit_add_delete_list'
         post 'tasks/update_add_delete_list'
         get 'tasks/edit_continue_or_destroy_step'
-        post 'tasks/update_continue_or_destroy_step'
         get 'tasks/edit_complete_or_continue_step'
-        post 'tasks/update_complete_or_continue_step'
         get 'tasks/edit_change_status_or_complete_task'
-        post 'tasks/update_change_status_or_complete_task'
       end
       resources :tasks do
         member do


### PR DESCRIPTION
## やったこと
・タスク状態によって制御する３つの画面でラジオボタンをやめて画面遷移せずに処理が完結するようにしました。
・済リスト、中止リストの件数を表示しました。
・完了日の未来の日付禁止バリデーションをapp/models/application_record.rbのものを使いました。
・app/models/application.rbのscopeとstatus?(status_name)メソッドを使って書き直しました。
・change_status_or_complete_taskの「進捗を未にする」、「すべてのタスクを未にする」でtransactionを使用しました。
・sort_orderメソッドをapp/controllers/leads/steps_controller.rbからapp/controllers/leads/application_controller.rbに移動しました。
## やらないこと
・taskのバリデーションをより厳しくすることはまだやっていません。
## できるようになること(ユーザ目線)
・タスク状態によって制御する画面の後、余計な画面遷移しなくてよくなる。
## できなくなること(ユーザ目線)
* タスク状態によって制御する画面でラジオボタンは使えなくなる。
##どのような動作確認を行ったのか? 結果はどうか?
・基本的なtaskのCRUD、チェックボックス、中止ボタン、復活ボタンが機能すること。タスク状態によって制御する画面で正しくtask,stepの状態を変更できること。
## その他
特にありません。
