### PR TITLE
案件の凍結処理、再開処理

### DIFF
--- a/app/assets/javascripts/leads/leads_statuses.coffee
+++ b/app/assets/javascripts/leads/leads_statuses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/leads/leads_statuses.scss
+++ b/app/assets/stylesheets/leads/leads_statuses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the leads/leads_statuses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -1,37 +1,68 @@
 class Leads::ApplicationController < Users::ApplicationController
   include LeadsHelper
   
+  # 案件の開始処理を実行
+  def start_lead(lead)
+    if lead.update_attributes(status: "in_progress", completed_date: "", canceled_date: "") && lead.valid?(:check_steps_status)
+      flash[:success] = "#{flash[:success]}本案件を再開しました。"
+      true
+    else
+      flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}"
+      false
+    end
+  end
+  
   # 進捗の開始処理を実行し詳細ページへ遷移
   def start_step(lead, step)
     @success_message = "" # transaction内で代入した値を使うため、インスタンス変数を用いている。""を代入してリセットしている。
     ActiveRecord::Base.transaction do
-        scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
-        case step.status
-        when "not_yet"
-          @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date)
-        when "inactive"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, canceled_date: "")
-        when "in_progress"
-          @success_message = "#{step.name}は既に進捗中です。"
-        when "completed"
-          @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "")
-        end
-       
+      # 開始処理
+      scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
+      case step.status
+      when "not_yet"
+        @success_message = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date)
+      when "inactive"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, canceled_date: "")
+      when "in_progress"
+        @success_message = "#{step.name}は既に進捗中です。"
+      when "completed"
+        @success_message = "#{step.name}を再開しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "")
+      end
+      # 完了する進捗がある場合の処理
       if params[:completed_id].present?
         completed_step = Step.find(params[:completed_id])
-        @success_message = "#{flash[:success]}#{step.name}を開始しました。" if complete_step(lead, completed_step, completed_step.latest_date)
+        @success_message = "#{step.name}を開始しました。" if complete_step(lead, completed_step, completed_step.latest_date)
       end
+      # 案件を再開する場合の処理
+      start_lead(lead) unless lead.status?("in_progress")
+      # 矛盾を解消
       check_status_completed_or_not(lead, step)
+      # バリデーション確認
       raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status) || step.errors.present?
     end
     if lead.errors.blank? && step.errors.blank?
-      flash[:success] = @success_message if @success_message.present?
+      flash[:success] = "#{flash[:success]}#{@success_message}" if @success_message.present?
     else
       flash.delete(:success)
-      flash[:danger] = lead.errors.full_messages.first if lead.errors.present?
-      flash[:danger] = step.errors.full_messages.first if step.errors.present?
+      flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}" if lead.errors.present?
+      flash[:danger] = "#{flash[:danger]}#{step.errors.full_messages.first}" if step.errors.present?
     end
     redirect_to step
+  end
+  
+  # 案件を凍結し詳細ページへ遷移
+  def cancel_lead(lead)
+    ActiveRecord::Base.transaction do
+      lead.update_attributes(status: "inactive", canceled_date: "#{Date.current}")
+      check_status_completed_or_not(lead, nil)
+      raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status)
+    end
+    if lead.errors.blank?
+      flash[:success] = "#{flash[:success]}本案件を凍結しました。以後、本案件は通知対象になりません。"
+    else
+      flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}"
+    end
+    redirect_to latest_step_in(lead)
   end
   
   # 進捗の中止処理を実行し詳細ページへ遷移
@@ -42,20 +73,20 @@ class Leads::ApplicationController < Users::ApplicationController
       raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status) || step.errors.present?
     end
     if lead.errors.blank? && step.errors.blank?
-      flash[:success] = "#{step.name}を保留にしました。以後、本進捗は通知対象になりません。"
+      flash[:success] = "#{flash[:success]}#{step.name}を保留にしました。以後、本進捗は通知対象になりません。"
     else
-      flash[:danger] = step.errors.full_messages.first
-      flash[:danger] = lead.errors.full_messages.first
+      flash[:danger] = "#{flash[:danger]}#{step.errors.full_messages.first}"
+      flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}"
     end
     redirect_to step
   end
   
-  # 進捗の中止状態を確認し、他カラムとの整合性を担保
-  def check_status_inactive_or_not(step)
-    if step.status?("inactive") && step.canceled_date.blank?
-      step.update_attribute(:canceled_date, "#{Date.current}")
-    elsif !step.status?("inactive") && step.canceled_date.present?
-      step.update_attribute(:canceled_date, "")
+  # 案件または進捗の中止状態を確認し、他カラムとの整合性を担保
+  def check_status_inactive_or_not(model)
+    if model.status?("inactive") && model.canceled_date.blank?
+      model.update_attribute(:canceled_date, "#{Date.current}")
+    elsif !model.status?("inactive") && model.canceled_date.present?
+      model.update_attribute(:canceled_date, "")
     end
   end
   
@@ -67,10 +98,10 @@ class Leads::ApplicationController < Users::ApplicationController
       raise ActiveRecord::Rollback if lead.invalid?(:check_steps_status)
     end
     if lead.errors.blank?
-      flash[:success] = "#{step.name}を削除しました。"
+      flash[:success] = "#{flash[:success]}#{step.name}を削除しました。"
       redirect_to working_step_in(lead)
     else
-      flash[:danger] = "#{step.name}を削除できませんでした。#{lead.errors.full_messages.first}"
+      flash[:danger] = "#{flash[:danger]}#{step.name}を削除できませんでした。#{lead.errors.full_messages.first}"
       redirect_to step
     end
   end
@@ -78,10 +109,10 @@ class Leads::ApplicationController < Users::ApplicationController
   # 本日付で案件の完了処理を実行
   def complete_lead(lead, completed_date)
     if lead.update_attributes(status: "completed", completed_date: completed_date)
-      flash[:success] = "全ての進捗が完了し、本案件は終了済となりました。おつかれさまでした。"
+      flash[:success] = "#{flash[:success]}全ての進捗が完了し、本案件は終了済となりました。おつかれさまでした。"
       true
     else
-      flash[:danger] = lead.errors.full_messages.first
+      flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}"
       false
     end
   end
@@ -90,10 +121,10 @@ class Leads::ApplicationController < Users::ApplicationController
   def complete_step(lead, step, completed_date)
     if step.update_attributes(status: "completed", completed_date: completed_date, completed_tasks_rate: 100)
       update_steps_rate(lead)
-      flash[:success] = "#{step.name}を完了しました。"
+      flash[:success] = "#{flash[:success]}#{step.name}を完了しました。"
       true
     else
-      flash[:danger] = step.errors.full_messages.first
+      flash[:danger] = "#{flash[:danger]}#{step.errors.full_messages.first}"
       false
     end
   end
@@ -114,12 +145,14 @@ class Leads::ApplicationController < Users::ApplicationController
         else
           step.update_attributes(completed_date: "")
         end
+        flash[:danger] = "#{flash[:danger]}未完了のタスクがあるため、#{step.name}を完了にできません。"
       elsif !step.status?("completed") && step.completed_tasks_rate == 100 # ここから完了状態に揃える処理
         if step.completed_date.blank?
           step.update_attributes(status: "completed", completed_date: "#{Date.current}")
         else
           step.update_attributes(status: "completed")
         end
+        flash[:success] = "#{flash[:success]}未完了のタスクがないため、#{step.name}は完了となりました。"
       end
     end
     
@@ -131,12 +164,14 @@ class Leads::ApplicationController < Users::ApplicationController
       else 
         lead.update_attributes(status: "in_progress")
       end
-    elsif !lead.status?("completed") && lead.steps_rate == 100 # ここから完了状態に揃える処理
+      flash[:danger] = "#{flash[:danger]}未完了の進捗があるため、案件を進捗中にしました。"
+    elsif lead.status?("in_progress") && lead.steps_rate == 100 # ここから完了状態に揃える処理
       if lead.completed_date.blank?
         lead.update_attributes(status: "completed", completed_date: "#{Date.current}")
       else
         lead.update_attributes(status: "completed")
       end
+      flash[:success] = "#{flash[:success]}未完了の進捗がないため、案件は終了済となりました。"
     end
     
   end

--- a/app/controllers/leads/leads_controller.rb
+++ b/app/controllers/leads/leads_controller.rb
@@ -78,6 +78,9 @@ class Leads::LeadsController < Leads::ApplicationController
   def update
     respond_to do |format|
       if @lead.update(lead_params) && update_steps_rate(@lead)
+        check_status_inactive_or_not(@lead)
+        check_status_completed_or_not(@lead, nil)
+        @lead.update_attribute(:notice_change_limit, true) if @lead.saved_change_to_scheduled_resident_date? || @lead.saved_change_to_scheduled_payment_date?
         format.html { redirect_to @lead, notice: 'Lead was successfully updated.' }
         format.json { render :show, status: :ok, location: @lead }
       else

--- a/app/controllers/leads/leads_statuses_controller.rb
+++ b/app/controllers/leads/leads_statuses_controller.rb
@@ -1,9 +1,6 @@
 class Leads::LeadsStatusesController < Leads::LeadsController
   before_action :correct_user, only: %i(start cancel)
   
-  def edit
-  end
-
   def start
     if start_lead(@lead)
       redirect_to Step.find(params[:step_id])
@@ -14,5 +11,6 @@ class Leads::LeadsStatusesController < Leads::LeadsController
 
   def cancel
     cancel_lead(@lead)
+    redirect_to latest_step_in(@lead)
   end
 end

--- a/app/controllers/leads/leads_statuses_controller.rb
+++ b/app/controllers/leads/leads_statuses_controller.rb
@@ -1,0 +1,18 @@
+class Leads::LeadsStatusesController < Leads::LeadsController
+  before_action :correct_user, only: %i(start cancel)
+  
+  def edit
+  end
+
+  def start
+    if start_lead(@lead)
+      redirect_to Step.find(params[:step_id])
+    else
+      redirect_to working_step_in(lead)
+    end
+  end
+
+  def cancel
+    cancel_lead(@lead)
+  end
+end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -32,6 +32,7 @@ class Leads::StepsController < Leads::ApplicationController
   def new
     @step = @lead.steps.new
     @completed_step = Step.find(params[:completed_id]) if params[:completed_id].present?
+    @start_lead_flag = true if params[:start_lead_flag].present?
   end
 
   # GET /steps/1/edit
@@ -103,6 +104,11 @@ class Leads::StepsController < Leads::ApplicationController
           @completed_step = Step.find(params[:step][:completed_id]) # 完了処理に失敗したら、改めてオブジェクトを渡す必要があるのでインスタンス変数を使用。
           errors << @completed_step.errors.full_messages unless complete_step(lead, @completed_step, @completed_step.latest_date)
         end
+        # 案件を再開する場合の処理
+        if params[:step][:start_lead_flag] == "true"
+          @start_lead_flag = true
+          errors << lead.errors.full_messages unless start_lead(lead)
+        end
         # 矛盾を解消
         check_status_inactive_or_not(step)
         check_status_completed_or_not(lead, step)
@@ -121,6 +127,7 @@ class Leads::StepsController < Leads::ApplicationController
         # 更新処理（バリデーションなし）
         prepare_order(step.order, params[:step][:order].to_i)
         step.update(step_params)
+        lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
         # 矛盾を解消
         check_status_inactive_or_not(step)
         check_status_completed_or_not(lead, step)

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -5,16 +5,23 @@ class Leads::StepsStatusesController < Leads::StepsController
   
   def complete
     if params[:completed_id].present?
+      completed_step = Step.find(params[:completed_id])
       ActiveRecord::Base.transaction do
-        completed_step = Step.find(params[:completed_id])
         complete_step(@lead, completed_step, completed_step.latest_date)
         if @lead.steps_rate < 100
-          flash[:success] = "#{flash[:success]}#{completed_step.name}を完了しました。引き続き、#{@step.name}に取り組んでください。"
+          flash[:success] = "#{flash[:success]}引き続き、#{@step.name}に取り組んでください。"
         else
           complete_lead(@lead, completed_step.latest_date)
         end
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
+      if @lead.errors.blank?
+        redirect_to @step
+      else
+        flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
+        redirect_to completed_step
+      end
+    else
       redirect_to @step
     end
   end

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -1,7 +1,5 @@
 class Leads::StepsStatusesController < Leads::StepsController
-  
-  def edit
-  end
+  before_action :set_steps, only: %i(cancel)
   
   def complete
     if params[:completed_id].present?

--- a/app/helpers/leads/leads_statuses_helper.rb
+++ b/app/helpers/leads/leads_statuses_helper.rb
@@ -1,0 +1,2 @@
+module Leads::LeadsStatusesHelper
+end

--- a/app/views/leads/leads/_lead_show.html.erb
+++ b/app/views/leads/leads/_lead_show.html.erb
@@ -1,0 +1,11 @@
+<h4><%= "#{@lead.customer_name} 様：「" %><%= link_to @lead.room_name, leads_path(room_searchword: @lead.room_name) %><%= "(#{@lead.room_num})」に入居予定" %></h4>
+<h5>
+  <%= "(担当：" %><%= link_to @user.name, leads_path(user_searchword: @user.id) %><%= "）" %>
+  <%= "：あなたの案件です。" if @lead.user_id == current_user.id %>
+  <%= link_to "：担当者を変更する", edit_user_id_lead_path(@lead) if current_user.superior? %>
+</h5>
+
+<h2 style="display:inline;"><%= "進捗率：#{@lead.steps_rate}%" %></h2>
+<h2 style="display:inline;"><%= " (現在：<STEP#{working_step_in(@lead).order}> #{@lead.status?("in_progress") ? working_step_in(@lead).name : @lead.status_i18n})" %></h2>
+<%= render 'leads/leads_statuses/start', lead: @lead, button_name: "再開" unless @lead.status?("in_progress") %>
+<br>

--- a/app/views/leads/leads/index.html.erb
+++ b/app/views/leads/leads/index.html.erb
@@ -61,7 +61,7 @@
         <tbody>
           <% @leads.each do |lead| %>
             <tr>
-              <td>(ここに遅延状況を表示)</td>
+              <td><%= "#{lead.status_i18n}" %><br>(ここに遅延状況を表示)</td>
               <td><%= User.find(lead.user_id).name %></td>
               <td><%= "#{lead.room_name} / #{lead.room_num}号室" %></td>
               <td><%= lead.customer_name %></td>

--- a/app/views/leads/leads_statuses/_start.html.erb
+++ b/app/views/leads/leads_statuses/_start.html.erb
@@ -1,0 +1,36 @@
+<!-- 本パーシャルを使用する場合は、before_actionとして、set_step及びset_stepsが必要。 -->
+<button type="button" class="btn btn-info" data-toggle="modal" data-target="#lead-start" data-name="<%= lead.customer_name %>" data-id="<%= lead.id %>"><%= button_name %></button>
+
+<!-- Modal -->
+<div class="modal fade" id="lead-start" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="lead-startLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="lead-startLabel">本案件を再開します。次に取り組む進捗を選択してください。</h5>
+        <button type="button" class="close pull-right" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <%= render 'leads/step_statuses/index', completed_step: nil %>
+        <%= link_to "新たに次の進捗を作成して進む", new_lead_step_path(@lead, start_lead_flag: true), class: "btn btn-primary btn-lg" %>
+      </div>
+      <div class="modal-footer">
+        <%= "* まだこの時点では案件は再開されていません。" %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script> 
+  $('#lead-start').on('show.bs.modal', function (event) {
+    var button = $(event.relatedTarget);
+    var id = button.data('id');
+    var name = button.data('name');
+    
+    var modal = $(this);
+    modal.find('.step-id').val(id);
+    modal.find('.step-name').text(name);
+  });
+</script>
+

--- a/app/views/leads/leads_statuses/_start.html.erb
+++ b/app/views/leads/leads_statuses/_start.html.erb
@@ -1,4 +1,4 @@
-<!-- 本パーシャルを使用する場合は、before_actionとして、set_step及びset_stepsが必要。 -->
+<!-- 本パーシャルを使用する場合は、オブジェクトとしてlead, button_nameが必要。before_actionとして、set_step及びset_stepsが必要。 -->
 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#lead-start" data-name="<%= lead.customer_name %>" data-id="<%= lead.id %>"><%= button_name %></button>
 
 <!-- Modal -->
@@ -12,7 +12,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <%= render 'leads/step_statuses/index', completed_step: nil %>
+        <%= render 'leads/step_statuses/index', steps: @steps, completed_step: nil %>
         <%= link_to "新たに次の進捗を作成して進む", new_lead_step_path(@lead, start_lead_flag: true), class: "btn btn-primary btn-lg" %>
       </div>
       <div class="modal-footer">

--- a/app/views/leads/step_statuses/_cancel.html.erb
+++ b/app/views/leads/step_statuses/_cancel.html.erb
@@ -1,2 +1,10 @@
-<%= link_to "#{button_name}", cancel_step_path(step), method: :patch, 
-  data: { confirm: '本進捗を保留にします。本当によろしいですか？（通知対象から外れます。）' }, class: "btn btn-danger btn-xs" %>
+<% if @steps_from_now_on.present? %>
+  <%= link_to "#{button_name}", cancel_step_path(step), method: :patch, 
+    data: { confirm: "本進捗を#{button_name}にします。本当によろしいですか？（通知対象から外れます。）" }, class: "btn btn-danger btn-xs" %>
+<% elsif lead.status?("in_progress") %>
+  <%= link_to "#{button_name}＋案件自体を完了", cancel_step_path(step), method: :patch, 
+    data: { confirm: "本進捗を#{button_name}にした上で、案件を終了します。本当によろしいですか？（案件自体が終了済の扱いになります。）" }, class: "btn btn-info btn-xs" %>
+  <%= link_to "#{button_name}＋案件も凍結", cancel_step_path(step, cancel_lead_flag: true), method: :patch, 
+    data: { confirm: "本進捗を#{button_name}にし、案件も凍結します。本当によろしいですか？（案件ごと通知対象から外れます。）" }, class: "btn btn-danger btn-xs" %>
+<% end %>
+

--- a/app/views/leads/step_statuses/_complete.html.erb
+++ b/app/views/leads/step_statuses/_complete.html.erb
@@ -1,4 +1,4 @@
-<!-- 本パーシャルを使用する場合は、before_actionとして、set_step及びset_stepsが必要。 -->
+<!-- 本パーシャルを使用する場合は、オブジェクトとしてsteps, completed_step, button_nameが必要。before_actionとして、set_step及びset_stepsが必要。 -->
 <button type="button" class="btn btn-info" data-toggle="modal" data-target="#step-complete" data-name="<%= completed_step.name %>" data-id="<%= completed_step.id %>"><%= button_name %></button>
 
 <!-- Modal -->
@@ -12,13 +12,13 @@
         </button>
       </div>
       <div class="modal-body">
-        <%= render 'leads/step_statuses/index', completed_step: completed_step %>
+        <%= render 'leads/step_statuses/index', steps: @steps_except_self, completed_step: completed_step %>
         <% if @steps_from_now_on.present? %>
           <%= link_to "新しく作成する場合はこちら", new_lead_step_path(@lead, completed_id: completed_step.id), class: "pull-right" %>
         <% else %>
-          <%= link_to "新たに次の進捗を作成して進む", new_lead_step_path(@lead, completed_id: completed_step.id), class: "btn btn-primary btn-lg" %>
+          <%= link_to "新たに次の進捗を作成して案件を続行", new_lead_step_path(@lead, completed_id: completed_step.id), class: "btn btn-primary btn-lg" %>
           <br><br>
-          <%= link_to "全ての進捗を完了＋案件自体を完了にする", complete_step_path(completed_step, completed_step), method: :patch, 
+          <%= link_to "全ての進捗を完了＋案件自体を完了", complete_step_path(completed_step, completed_step), method: :patch, 
             data: { confirm: '本案件を全て完了とします。本当によろしいですか？（終了済の扱いになります。）' }, class: "btn btn-info btn-lg pull-right" %>
         <% end %>
       </div>

--- a/app/views/leads/step_statuses/_complete.html.erb
+++ b/app/views/leads/step_statuses/_complete.html.erb
@@ -12,48 +12,7 @@
         </button>
       </div>
       <div class="modal-body">
-        進捗一覧<br>
-        <table class="table table-hover" id="table-shops">
-          <tbody>
-            <% @steps_except_self.each do |step| %>
-              <tr>
-                <td>Step<%= step.order %></td>
-                <% if step.status?("not_yet") %>
-                  <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を設定して開始する" %></td>
-                <% elsif step.status?("inactive") %>
-                  <td>
-                    <p>
-                      <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
-                    	  <%= "(#{step.status_i18n})" %>
-                      </a>
-                    </p>
-                    <div id="collapseStep<%= step.id %>" class="collapse">
-                    	<div class="well">
-                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を再設定して再開する" %>
-                    	</div>
-                    </div>
-                  </td>
-                <% elsif step.status?("in_progress") %>
-                  <td><%= link_to "＜#{step.status_i18n}＞#{step.name}を継続", complete_step_path(step, completed_step), method: :patch, class: "btn btn-info btn-sm" %></td>
-                <% elsif step.status?("completed") %>
-                  <td>
-                    <p>
-                      <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
-                    	  <%= step.status_i18n %>
-                      </a>
-                    </p>
-                    <div id="collapseStep<%= step.id %>" class="collapse">
-                    	<div class="well">
-                        <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step.id, button_name: "完了予定日を再設定して再開する" %>
-                    	</div>
-                    </div>
-                  </td>
-                <% end %>
-                <td><%= link_to "詳細確認", step_path(step), target: :_blank %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <%= render 'leads/step_statuses/index', completed_step: completed_step %>
         <% if @steps_from_now_on.present? %>
           <%= link_to "新しく作成する場合はこちら", new_lead_step_path(@lead, completed_id: completed_step.id), class: "pull-right" %>
         <% else %>

--- a/app/views/leads/step_statuses/_index.html.erb
+++ b/app/views/leads/step_statuses/_index.html.erb
@@ -1,9 +1,16 @@
+<!-- 本パーシャルを使用する場合は、オブジェクトとしてsteps, completed_stepが必要。before_actionとして、set_stepが必要。 -->
 進捗一覧<br>
 <table class="table table-hover" id="table-shops">
   <tbody>
-    <% @steps_except_self.each do |step| %>
+    <% steps.each do |step| %>
       <tr>
-        <td>Step<%= step.order %></td>
+        <td>
+          <p>
+            <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
+          	  <%= "Step #{step.order}" %>
+            </a>
+          </p>
+        </td>
         <% if step.status?("not_yet") %>
           <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, button_name: "完了予定日を設定して開始する" %></td>
         <% elsif step.status?("inactive") %>

--- a/app/views/leads/step_statuses/_index.html.erb
+++ b/app/views/leads/step_statuses/_index.html.erb
@@ -1,0 +1,49 @@
+進捗一覧<br>
+<table class="table table-hover" id="table-shops">
+  <tbody>
+    <% @steps_except_self.each do |step| %>
+      <tr>
+        <td>Step<%= step.order %></td>
+        <% if step.status?("not_yet") %>
+          <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, button_name: "完了予定日を設定して開始する" %></td>
+        <% elsif step.status?("inactive") %>
+          <td>
+            <p>
+              <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
+            	  <%= "(#{step.status_i18n})" %>
+              </a>
+            </p>
+            <div id="collapseStep<%= step.id %>" class="collapse">
+            	<div class="well">
+                <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, button_name: "完了予定日を再設定して再開する" %>
+            	</div>
+            </div>
+          </td>
+        <% elsif step.status?("in_progress") %>
+          <td>
+            <% if completed_step.present? %>
+              <%= link_to "＜#{step.status_i18n}＞#{step.name}を継続", complete_step_path(step, completed_step), method: :patch, class: "btn btn-info btn-sm" %>
+            <% else %>
+              <%= link_to "＜#{step.status_i18n}＞#{step.name}を継続", start_lead_path(@lead, step), method: :patch, class: "btn btn-info btn-sm" %>
+            <% end %>
+          </td>
+        <% elsif step.status?("completed") %>
+          <td>
+            <p>
+              <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
+            	  <%= step.status_i18n %>
+              </a>
+            </p>
+            <div id="collapseStep<%= step.id %>" class="collapse">
+            	<div class="well">
+                <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, button_name: "完了予定日を再設定して再開する" %>
+            	</div>
+            </div>
+          </td>
+        <% end %>
+        <td><%= link_to "詳細確認", step_path(step), target: :_blank %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/app/views/leads/step_statuses/_index.html.erb
+++ b/app/views/leads/step_statuses/_index.html.erb
@@ -7,7 +7,7 @@
         <td>
           <p>
             <a class="btn btn-default btn-xs" data-toggle="collapse" href="#collapseStep<%= step.id %>">
-          	  <%= "Step #{step.order}" %>
+              <%= "Step #{step.order}" %>
             </a>
           </p>
         </td>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -6,12 +6,14 @@
     <%= form.text_field :name, autofocus: true %>
   </div>
 
+  <% steps_count = @lead.steps.count %>
   <div class="field">
     <%= form.label :order %>＜入力必須＞
     <% if step.new_record? %>
-      <%= form.number_field :order, min: 1, max: @lead.steps.count + 1, value: params[:order_num].to_i %>
+      <% order_num = params[:order_num].present? ? params[:order_num].to_i : steps_count + 1 %>
+      <%= form.number_field :order, min: 1, max: steps_count + 1, value: order_num %>
     <% else %>
-      <%= form.number_field :order, min: 1, max: @lead.steps.count %>
+      <%= form.number_field :order, min: 1, max: steps_count %>
     <% end %>
   </div>
 

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -21,6 +21,7 @@
   </div>
 
 ----------------------------------------------------------------
+  <%= form.hidden_field :start_lead_flag, value: true if @start_lead_flag %>
 
   <% if @completed_step.present? %>
 

--- a/app/views/leads/steps/_steps_index.html.erb
+++ b/app/views/leads/steps/_steps_index.html.erb
@@ -43,6 +43,6 @@
     <% end %>
     <td><%= link_to ">", new_lead_step_path(@lead, order_num: @lead.steps.count + 1) %></td>
     <td>完了！</td>
-  </td>
+  </tr>
 </table>
 

--- a/app/views/leads/steps/_steps_index.html.erb
+++ b/app/views/leads/steps/_steps_index.html.erb
@@ -1,0 +1,48 @@
+<% arrow_mark = "▽" %>
+<% flag_scheduled_resident_date = true %>
+<% flag_scheduled_payment_date = true %>
+<% flag_scheduled_contract_date = @lead.scheduled_contract_date.present? %>
+<table>
+  <tr>
+    <td colspan="1"><%= l(Time.parse(@lead.created_date), format: :date) %><br><%= arrow_mark %></td>
+    <% @steps.each do |step| %>
+      <td>
+        <% if flag_scheduled_resident_date && @lead.scheduled_resident_date < step.finish_date %>
+          <br>入居<br><%= l(Time.parse(@lead.scheduled_resident_date), format: :shortdate) %><br><%= arrow_mark %>
+          <% flag_scheduled_resident_date = false %>
+        <% end %>
+        <% if flag_scheduled_payment_date && @lead.scheduled_payment_date < step.finish_date %>
+          <br>入金<br><%= l(Time.parse(@lead.scheduled_payment_date), format: :shortdate) %><br><%= arrow_mark %>
+          <% flag_scheduled_payment_date = false %>
+        <% end %>
+        <% if flag_scheduled_contract_date && @lead.scheduled_contract_date < step.finish_date %>
+          <br>契約<br><%= l(Time.parse(@lead.scheduled_contract_date), format: :shortdate) %><br><%= arrow_mark %>
+          <% flag_scheduled_contract_date = false %>
+        <% end %>
+      <td></td>
+      </td>
+    <% end %>
+    <td>
+      <% if flag_scheduled_resident_date %>
+        <br>入居<br><%= l(Time.parse(@lead.scheduled_resident_date), format: :shortdate) %><br><%= arrow_mark %>
+      <% end %>
+      <% if flag_scheduled_payment_date %>
+        <br>入金<br><%= l(Time.parse(@lead.scheduled_payment_date), format: :shortdate) %><br><%= arrow_mark %>
+      <% end %>
+      <% if flag_scheduled_contract_date %>
+        <br>契約<br><%= l(Time.parse(@lead.scheduled_contract_date), format: :shortdate) %><br><%= arrow_mark %>
+      <% end %>
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>申込</td>
+    <% @steps.each do |step| %>
+      <td><%= link_to ">", new_lead_step_path(@lead, order_num: step.order) %></td>
+      <td><%= link_to "#{step.order}", step_path(step), class: "btn #{step_button_color(step)} #{step_button_size(@step, step)}" %></td>
+    <% end %>
+    <td><%= link_to ">", new_lead_step_path(@lead, order_num: @lead.steps.count + 1) %></td>
+    <td>完了！</td>
+  </td>
+</table>
+

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -118,6 +118,21 @@
   <%= @lead.scheduled_contract_date %>
 </p>
 
+<p>
+  <strong>Created date:</strong>
+  <%= @lead.created_date %>
+</p>
+
+<p>
+  <strong>Completed date:</strong>
+  <%= @lead.completed_date %>
+</p>
+
+<p>
+  <strong>canceled_date:</strong>
+  <%= @lead.canceled_date %>
+</p>
+
 
 <%= link_to "担当者を変更する", edit_user_id_lead_path(@lead) if current_user.superior? %>
 

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -1,65 +1,7 @@
 <p id="notice"><%= notice %></p>
 
-<h4><%= "#{@lead.customer_name} 様：「" %><%= link_to @lead.room_name, leads_path(room_searchword: @lead.room_name) %><%= "(#{@lead.room_num})」に入居予定" %></h4>
-<h5>
-  <%= "(担当：" %><%= link_to @user.name, leads_path(user_searchword: @user.id) %><%= "）" %>
-  <%= "：あなたの案件です。" if @lead.user_id == current_user.id %>
-  <%= link_to "：担当者を変更する", edit_user_id_lead_path(@lead) if current_user.superior? %>
-</h5>
-
-<h2 style="display:inline;"><%= "進捗率：#{@lead.steps_rate}%" %></h2>
-<h2 style="display:inline;"><%= " (現在：<STEP#{working_step_in(@lead).order}> #{@lead.status?("in_progress") ? working_step_in(@lead).name : @lead.status_i18n})" %></h2>
-<br>
-
-<%= render 'leads/leads_statuses/start', lead: @lead, button_name: "再開" %>
-
-<% arrow_mark = "▽" %>
-<% flag_scheduled_resident_date = true %>
-<% flag_scheduled_payment_date = true %>
-<% flag_scheduled_contract_date = @lead.scheduled_contract_date.present? %>
-<table>
-  <tr>
-    <td colspan="1"><%= l(Time.parse(@lead.created_date), format: :date) %><br><%= arrow_mark %></td>
-    <% @steps.each do |step| %>
-      <td>
-        <% if flag_scheduled_resident_date && @lead.scheduled_resident_date < step.finish_date %>
-          <br>入居<br><%= l(Time.parse(@lead.scheduled_resident_date), format: :shortdate) %><br><%= arrow_mark %>
-          <% flag_scheduled_resident_date = false %>
-        <% end %>
-        <% if flag_scheduled_payment_date && @lead.scheduled_payment_date < step.finish_date %>
-          <br>入金<br><%= l(Time.parse(@lead.scheduled_payment_date), format: :shortdate) %><br><%= arrow_mark %>
-          <% flag_scheduled_payment_date = false %>
-        <% end %>
-        <% if flag_scheduled_contract_date && @lead.scheduled_contract_date < step.finish_date %>
-          <br>契約<br><%= l(Time.parse(@lead.scheduled_contract_date), format: :shortdate) %><br><%= arrow_mark %>
-          <% flag_scheduled_contract_date = false %>
-        <% end %>
-      <td></td>
-      </td>
-    <% end %>
-    <td>
-      <% if flag_scheduled_resident_date %>
-        <br>入居<br><%= l(Time.parse(@lead.scheduled_resident_date), format: :shortdate) %><br><%= arrow_mark %>
-      <% end %>
-      <% if flag_scheduled_payment_date %>
-        <br>入金<br><%= l(Time.parse(@lead.scheduled_payment_date), format: :shortdate) %><br><%= arrow_mark %>
-      <% end %>
-      <% if flag_scheduled_contract_date %>
-        <br>契約<br><%= l(Time.parse(@lead.scheduled_contract_date), format: :shortdate) %><br><%= arrow_mark %>
-      <% end %>
-    </td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>申込</td>
-    <% @steps.each do |step| %>
-      <td><%= link_to ">", new_lead_step_path(@lead, order_num: step.order) %></td>
-      <td><%= link_to "#{step.order}", step_path(step), class: "btn #{step_button_color(step)} #{step_button_size(@step, step)}" %></td>
-    <% end %>
-    <td><%= link_to ">", new_lead_step_path(@lead, order_num: @lead.steps.count + 1) %></td>
-    <td>完了！</td>
-  </td>
-</table>
+<%= render partial: 'leads/leads/lead_show' %>
+<%= render partial: 'leads/steps/steps_index' %>
 
 <br>////////////////////////////////////////////////////////////////////////////////////////////////////////////<br>
 
@@ -94,10 +36,10 @@
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
       <% when "inactive" %>
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
-        <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch %>
+        <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch unless @lead.status?("inactive") %>
       <% when "in_progress" %>
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
-        <%= render 'leads/step_statuses/cancel', step: @step, button_name: "保留" %>
+        <%= render 'leads/step_statuses/cancel', lead: @lead, step: @step, button_name: "保留" %>
       <% when "completed" %>
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
       <% when "template" %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -11,6 +11,8 @@
 <h2 style="display:inline;"><%= " (現在：<STEP#{working_step_in(@lead).order}> #{@lead.status?("in_progress") ? working_step_in(@lead).name : @lead.status_i18n})" %></h2>
 <br>
 
+<%= render 'leads/leads_statuses/start', lead: @lead, button_name: "再開" %>
+
 <% arrow_mark = "▽" %>
 <% flag_scheduled_resident_date = true %>
 <% flag_scheduled_payment_date = true %>
@@ -20,7 +22,6 @@
     <td colspan="1"><%= l(Time.parse(@lead.created_date), format: :date) %><br><%= arrow_mark %></td>
     <% @steps.each do |step| %>
       <td>
-        <%# debugger %>
         <% if flag_scheduled_resident_date && @lead.scheduled_resident_date < step.finish_date %>
           <br>入居<br><%= l(Time.parse(@lead.scheduled_resident_date), format: :shortdate) %><br><%= arrow_mark %>
           <% flag_scheduled_resident_date = false %>
@@ -73,6 +74,7 @@
     <% when "in_progress" %>
       <%= "進捗中" %>
       <%= "：#{l(Time.parse(@step.scheduled_complete_date), format: :shortdate)}迄" %>
+      <%#= "（期限変更：上司未確認）" if @lead.notice_change_limit && @step.notice_change_limit %>
     <% when "completed" %>
       <%= "#{l(Time.parse(@step.completed_date), format: :shortdate)}に完了済" %>
     <% when "template" %>
@@ -86,11 +88,13 @@
 <div id="collapse-step-status-edit" class="collapse">
   <div class="well">
     <h5 style="display:inline;">
+      <%= @step.memo %><br>
       <% case @step.status %>
       <% when "not_yet" %>
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "開始" %>
       <% when "inactive" %>
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, button_name: "再開" %>
+        <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch %>
       <% when "in_progress" %>
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
         <%= render 'leads/step_statuses/cancel', step: @step, button_name: "保留" %>
@@ -106,9 +110,8 @@
 
 <%= render partial: 'leads/tasks/tasks_index' %>
 
-<!--%= link_to 'Task-index', step_tasks_path(@step) %> |-->
-<%= link_to 'Edit', edit_step_path(@step) %> |
-<%= link_to 'Back', lead_steps_path(@lead) %>
+<%= link_to '案件の編集', edit_lead_path(@lead) %> |
+<%= link_to '案件一覧へ戻る', leads_path %>
 
 
 <br>
@@ -120,6 +123,12 @@
 ページはここまで。
 <br>////////////////////////////////////////////////////////////////////////////////////////////////////////////<br>
 以下はメモです。（最終プルリク上げる前に削除）
+
+期限変更：<%= @lead.notice_change_limit %>
+<br>
+<%= link_to '進捗編集', edit_step_path(@step) %> |
+<%= link_to '進捗一覧', lead_steps_path(@lead) %>
+
 <div class="row">
   <div class="col-md-12 col-md-offset-1">
     <table id="table-lead-index-show">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
     member do
       get 'edit_user_id'
       patch 'update_user_id'
+      get 'edit_status' => 'leads_statuses#edit', as: :edit_statuses_of
+      patch 'start/:step_id' => 'leads_statuses#start', as: :start
+      patch 'cancel' => 'leads_statuses#cancel', as: :cancel
     end
     resources :steps do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,13 +19,11 @@ Rails.application.routes.draw do
     member do
       get 'edit_user_id'
       patch 'update_user_id'
-      get 'edit_status' => 'leads_statuses#edit', as: :edit_statuses_of
       patch 'start/:step_id' => 'leads_statuses#start', as: :start
       patch 'cancel' => 'leads_statuses#cancel', as: :cancel
     end
     resources :steps do
       member do
-        get 'edit_status' => 'steps_statuses#edit', as: :edit_statuses_of
         patch 'complete/:completed_id' => 'steps_statuses#complete', as: :complete
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel

--- a/spec/requests/leads/leads_statuses_request_spec.rb
+++ b/spec/requests/leads/leads_statuses_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Leads::LeadsStatuses", type: :request do
+
+  describe "GET /start" do
+    it "returns http success" do
+      get "/leads/leads_statuses/start"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /cancel" do
+    it "returns http success" do
+      get "/leads/leads_statuses/cancel"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## やったこと
* 案件の凍結及び再開処理（cancel_leadメソッド、start_leadメソッドの追加、leads_statusコントローラの追加）
* 案件詳細ページが大きくなってきたので、部分ごとにパーシャル化
* 進捗の完了予定日を変更した際に、通知フラグをtrueにするコードを追加（現在コメントアウト中）
## やらないこと
* 通知フラグをfalseにする処理は追加していません。そちらが追加されたら、上記コメントアウトを外すことで考えております。
* そろそろ、どんな手動テストをすれば問題なしと判断できるか、明文化しておく必要があるな、と考えております。
## できるようになること(ユーザ目線)
* 案件の凍結処理
* 凍結または完了した案件の再開処理
## できなくなること(ユーザ目線)
* なし
## 動作確認
* 進捗の開始、完了、凍結、案件の完了、凍結、再開の流れを一通り行った。（上記でも書きましたが、「一通り」の内容を書き出しておく必要あり、と感じました。）
## その他
* なし