### PR TITLE
Stricten task validation 2

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -208,24 +208,24 @@ class Leads::ApplicationController < Users::ApplicationController
   end
 
   # タスクの状態に応じてリダイレクト先を取得する
-  def check_status_and_get_url  
+  def check_status_and_get_url(step) 
     # タスク操作後、
 
     # 進捗に「未」のタスクが無く、かつ「完了」のタスクも無い場合、continue_or_destroy_stepのurlにリダイレクトする
-    if @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").nil?
-      edit_continue_or_destroy_step_task_url(@step)
+    if step.tasks.find_by(status: "not_yet").nil? && step.tasks.find_by(status: "completed").nil?
+      edit_continue_or_destroy_step_task_url(step)
 
     #進捗に「未」のタスクが無く、かつ「完了」のタスクが１つ以上ある場合、complete_or_continue_stepのurlにリダイレクトする
-    elsif @step.tasks.find_by(status: "not_yet").nil? && @step.tasks.find_by(status: "completed").present?
-      edit_complete_or_continue_step_task_url(@step)
+    elsif step.tasks.find_by(status: "not_yet").nil? && step.tasks.find_by(status: "completed").present?
+      edit_complete_or_continue_step_task_url(step)
 
     #進捗に「未」のタスクがあるにも関わらず、進捗のstatusが「完了」の場合、change_status_or_complete_taskのurlにリダイレクトする
-    elsif @step.tasks.find_by(status: "not_yet").present? && @step.status?("completed")
-      edit_change_status_or_complete_task_task_url(@step)
+    elsif step.tasks.find_by(status: "not_yet").present? && step.status?("completed")
+      edit_change_status_or_complete_task_task_url(step)
 
     #以上いずれでもない場合、steps#showにリダイレクトする
     else
-      step_url(@step)
+      step_url(step)
     end 
   end
 

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -17,7 +17,7 @@ class Leads::ApplicationController < Users::ApplicationController
     ActiveRecord::Base.transaction do
       # 作成するタスクがある場合の処理
       if params[:new_task].present? && step.tasks.not_yet.blank?
-        Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}") if params[:new_task] == "true"
+        Task.create!(step_id: step.id ,name: "new_task", status: "not_yet", scheduled_complete_date: "#{Date.current}") if params[:new_task] == "true"
       end
       # 進捗開始処理
       scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -208,7 +208,7 @@ class Leads::ApplicationController < Users::ApplicationController
   end
 
   # タスクの状態に応じてリダイレクト先を取得する
-  def check_status_and_get_url(step) 
+  def check_status_and_get_url(step, redirect_to_step) 
     # タスク操作後、
 
     # 進捗に「未」のタスクが無く、かつ「完了」のタスクも無い場合、continue_or_destroy_stepのurlにリダイレクトする
@@ -225,7 +225,7 @@ class Leads::ApplicationController < Users::ApplicationController
 
     #以上いずれでもない場合、steps#showにリダイレクトする
     else
-      step_url(step)
+      step_url(redirect_to_step)
     end 
   end
 

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -45,7 +45,12 @@ class Leads::ApplicationController < Users::ApplicationController
     end
     
     if params[:completed_id].present? && lead.errors.blank? && step.errors.blank?
-      redirect_to check_status_and_get_url(@completed_step, step)
+      if $step_num == 0
+        $step_num += 1
+        redirect_to check_status_and_get_url(@completed_step, step)
+      else
+        redirect_to step
+      end 
     else 
       redirect_to step
     end

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -45,12 +45,7 @@ class Leads::ApplicationController < Users::ApplicationController
     end
     
     if params[:completed_id].present? && lead.errors.blank? && step.errors.blank?
-      unless $through_check_status
-        $through_check_status = true
-        redirect_to check_status_and_get_url(@completed_step, step)
-      else
-        redirect_to step
-      end 
+      check_status_and_redirect(@completed_step, step)
     else 
       redirect_to step
     end
@@ -239,6 +234,17 @@ class Leads::ApplicationController < Users::ApplicationController
       step_url(redirect_to_step)
     end 
   end
+
+  #$through_check_statusに応じてリダイレクト先を選択する
+  def check_status_and_redirect(step, redirect_to_step)
+    unless $through_check_status
+      $through_check_status = true
+      redirect_to check_status_and_get_url(step, redirect_to_step)
+    else
+      redirect_to redirect_to_step
+    end
+  end
+
 
   private
     # 進捗一覧を取得

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -28,8 +28,8 @@ class Leads::ApplicationController < Users::ApplicationController
       end
       # 完了する進捗がある場合の処理
       if params[:completed_id].present?
-        completed_step = Step.find(params[:completed_id])
-        complete_step(lead, completed_step, completed_step.latest_date)
+        @completed_step = Step.find(params[:completed_id])
+        complete_step(lead, @completed_step, @completed_step.latest_date)
       end
       # 案件を再開する場合の処理
       start_lead(lead) unless lead.status?("in_progress")
@@ -43,7 +43,12 @@ class Leads::ApplicationController < Users::ApplicationController
       flash[:danger] = "#{flash[:danger]}#{lead.errors.full_messages.first}" if lead.errors.present?
       flash[:danger] = "#{flash[:danger]}#{step.errors.full_messages.first}" if step.errors.present?
     end
-    redirect_to step
+    
+    if params[:completed_id].present? && lead.errors.blank? && step.errors.blank?
+      redirect_to check_status_and_get_url(@completed_step, step)
+    else 
+      redirect_to step
+    end
   end
   
   # 案件を凍結処理を実行

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -45,7 +45,7 @@ class Leads::ApplicationController < Users::ApplicationController
     end
     
     if params[:completed_id].present? && lead.errors.blank? && step.errors.blank?
-      check_status_and_redirect(@completed_step, step)
+      check_status_and_redirect_to(@completed_step, step)
     else 
       redirect_to step
     end
@@ -236,7 +236,7 @@ class Leads::ApplicationController < Users::ApplicationController
   end
 
   #$through_check_statusに応じてリダイレクト先を選択する
-  def check_status_and_redirect(step, redirect_to_step)
+  def check_status_and_redirect_to(step, redirect_to_step)
     unless $through_check_status
       $through_check_status = true
       redirect_to check_status_and_get_url(step, redirect_to_step)

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -82,7 +82,7 @@ class Leads::StepsController < Leads::ApplicationController
       errors << @lead.errors.full_messages if @lead.invalid?(:check_steps_status)
       raise ActiveRecord::Rollback if errors.present?
     end
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
   private

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -82,7 +82,7 @@ class Leads::StepsController < Leads::ApplicationController
       errors << @lead.errors.full_messages if @lead.invalid?(:check_steps_status)
       raise ActiveRecord::Rollback if errors.present?
     end
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
   private

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -48,21 +48,11 @@ class Leads::StepsController < Leads::ApplicationController
       flash[:success] = "#{flash[:success]}#{@step.name}を作成しました。"
       if params[:step][:completed_id].present?
         @completed_step.update_attributes(status: "completed", completed_date: "#{Date.current}")
-        unless $through_check_status
-          $through_check_status = true
-          redirect_to check_status_and_get_url(@completed_step, @step)
-        else
-          redirect_to @step
-        end
+        check_status_and_redirect(@completed_step, @step)
       elsif params[:step][:status].present? && params[:step][:status] == "completed"
         scheduled_complete_date = params[:step][:scheduled_complete_date].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
         Task.create!(step_id: @step.id ,name: "completed_task", status: "completed", scheduled_complete_date: scheduled_complete_date, completed_date: params[:step][:completed_date]) 
-        unless $through_check_status
-          $through_check_status = true
-          redirect_to check_status_and_get_url(@step, @step)
-        else
-          redirect_to @step
-        end
+        check_status_and_redirect(@step, @step)
       else
         redirect_to @step
       end
@@ -79,12 +69,7 @@ class Leads::StepsController < Leads::ApplicationController
   def update
     if update_and_errors_of(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を更新しました。"
-      unless $through_check_status
-        $through_check_status = true
-        redirect_to check_status_and_get_url(@step, @step)
-      else
-        redirect_to @step
-      end
+      check_status_and_redirect(@step, @step)
     else
       flash.delete(:success)
       flash.now[:danger] = @lead.errors.full_messages.first if @lead.errors.present?

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -48,11 +48,11 @@ class Leads::StepsController < Leads::ApplicationController
       flash[:success] = "#{flash[:success]}#{@step.name}を作成しました。"
       if params[:step][:completed_id].present?
         @completed_step.update_attributes(status: "completed", completed_date: "#{Date.current}")
-        check_status_and_redirect(@completed_step, @step)
+        check_status_and_redirect_to(@completed_step, @step)
       elsif params[:step][:status].present? && params[:step][:status] == "completed"
         scheduled_complete_date = params[:step][:scheduled_complete_date].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
         Task.create!(step_id: @step.id ,name: "completed_task", status: "completed", scheduled_complete_date: scheduled_complete_date, completed_date: params[:step][:completed_date]) 
-        check_status_and_redirect(@step, @step)
+        check_status_and_redirect_to(@step, @step)
       else
         redirect_to @step
       end
@@ -69,7 +69,7 @@ class Leads::StepsController < Leads::ApplicationController
   def update
     if update_and_errors_of(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を更新しました。"
-      check_status_and_redirect(@step, @step)
+      check_status_and_redirect_to(@step, @step)
     else
       flash.delete(:success)
       flash.now[:danger] = @lead.errors.full_messages.first if @lead.errors.present?

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -45,7 +45,11 @@ class Leads::StepsController < Leads::ApplicationController
     @step = @lead.steps.new(step_params)
     if save_and_errors_of(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を作成しました。"
-      redirect_to @step
+      if params[:step][:completed_id].present?
+        redirect_to check_status_and_get_url(@completed_step, @step)
+      else
+        redirect_to @step
+      end
     else
       flash.delete(:success)
       flash.now[:danger] = "#{@lead.errors.full_messages.first}" if @lead.errors.present?
@@ -59,7 +63,7 @@ class Leads::StepsController < Leads::ApplicationController
   def update
     if update_and_errors_of(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を更新しました。"
-      redirect_to @step
+      redirect_to check_status_and_get_url(@step, @step)
     else
       flash.delete(:success)
       flash.now[:danger] = @lead.errors.full_messages.first if @lead.errors.present?

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -56,7 +56,7 @@ class Leads::StepsController < Leads::ApplicationController
         end
       elsif params[:step][:status].present? && params[:step][:status] == "completed"
         scheduled_complete_date = params[:step][:scheduled_complete_date].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
-        Task.create!(step_id: @step.id ,name: "completed_task", status: 1, scheduled_complete_date: scheduled_complete_date, completed_date: params[:step][:completed_date]) 
+        Task.create!(step_id: @step.id ,name: "completed_task", status: "completed", scheduled_complete_date: scheduled_complete_date, completed_date: params[:step][:completed_date]) 
         unless $through_check_status
           $through_check_status = true
           redirect_to check_status_and_get_url(@step, @step)
@@ -147,7 +147,7 @@ class Leads::StepsController < Leads::ApplicationController
         end
         # 新規タスク作成
         if !step.status?("completed") && step.tasks.not_yet.blank? 
-          Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: params[:step][:scheduled_complete_date])
+          Task.create!(step_id: step.id ,name: "new_task", status: "not_yet", scheduled_complete_date: params[:step][:scheduled_complete_date])
         end
         # 矛盾を解消
         check_status_inactive_or_not(step)
@@ -170,7 +170,7 @@ class Leads::StepsController < Leads::ApplicationController
         lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
         # 新規タスク作成
         if params[:step][:status] == "in_progress" && step.tasks.not_yet.blank?
-          Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: params[:step][:scheduled_complete_date])
+          Task.create!(step_id: step.id ,name: "new_task", status: "not_yet", scheduled_complete_date: params[:step][:scheduled_complete_date])
         end
         # 矛盾を解消
         check_status_inactive_or_not(step)

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,7 +14,12 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        redirect_to @step
+        if $step_num == 0
+          $step_num += 1
+          redirect_to check_status_and_get_url(completed_step, @step)
+        else
+          redirect_to @step
+        end
       else
         flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
         redirect_to completed_step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,12 +14,7 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        unless $through_check_status
-          $through_check_status = true
-          redirect_to check_status_and_get_url(completed_step, @step)
-        else
-          redirect_to @step
-        end
+        check_status_and_redirect(completed_step, @step)
       else
         flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
         redirect_to completed_step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,7 +14,7 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        redirect_to check_status_and_get_url(completed_step, @step)
+        redirect_to @step
       else
         flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
         redirect_to completed_step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,8 +14,8 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        if $step_num == 0
-          $step_num += 1
+        unless $through_check_status
+          $through_check_status = true
           redirect_to check_status_and_get_url(completed_step, @step)
         else
           redirect_to @step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,7 +14,7 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        check_status_and_redirect(completed_step, @step)
+        check_status_and_redirect_to(completed_step, @step)
       else
         flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
         redirect_to completed_step

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -14,7 +14,7 @@ class Leads::StepsStatusesController < Leads::StepsController
         raise ActiveRecord::Rollback if @lead.invalid?(:check_steps_status)
       end
       if @lead.errors.blank?
-        redirect_to @step
+        redirect_to check_status_and_get_url(completed_step, @step)
       else
         flash[:danger] = "#{flash[:danger]}#{@lead.errors.full_messages.first}"
         redirect_to completed_step

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -36,7 +36,7 @@ class Leads::TasksController < Leads::ApplicationController
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save && update_completed_tasks_rate(@step)
-      redirect_to check_status_and_get_url(@step)
+      redirect_to check_status_and_get_url(@step, @step)
     else
       render :new 
     end
@@ -56,7 +56,7 @@ class Leads::TasksController < Leads::ApplicationController
       elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
-      redirect_to check_status_and_get_url(@step)
+      redirect_to check_status_and_get_url(@step ,@step)
     else
       render :edit
     end
@@ -65,7 +65,7 @@ class Leads::TasksController < Leads::ApplicationController
   def destroy
     @task.destroy
     update_completed_tasks_rate(@step)
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
   # 「To Do リスト」にチェックを入れて「更新」ボタンを押したときに実行されるアクション
@@ -103,7 +103,7 @@ class Leads::TasksController < Leads::ApplicationController
         end
       end
     end
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
   # 「To Do リスト」で中止ボタンを押して「中止」リストに入れる処理
@@ -111,7 +111,7 @@ class Leads::TasksController < Leads::ApplicationController
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
     @task.update_attribute(:canceled_date, "#{Date.current}") if @task.canceled_date.blank?
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
   # 復活ボタンを押したときに実行されるアクション
@@ -128,7 +128,7 @@ class Leads::TasksController < Leads::ApplicationController
     else
       flash[:danger] = "#{@task.name}の更新は失敗しました。" + @task.errors.full_messages[0]
     end
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
   def edit_continue_or_destroy_step
@@ -151,7 +151,7 @@ class Leads::TasksController < Leads::ApplicationController
       update_completed_tasks_rate(@step)
       raise ActiveRecord::Rollback if errors.present?
     end
-    redirect_to check_status_and_get_url(@step)
+    redirect_to check_status_and_get_url(@step, @step)
   end
 
 

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -36,7 +36,7 @@ class Leads::TasksController < Leads::ApplicationController
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save && update_completed_tasks_rate(@step)
-      redirect_to check_status_and_get_url
+      redirect_to check_status_and_get_url(@step)
     else
       render :new 
     end
@@ -56,7 +56,7 @@ class Leads::TasksController < Leads::ApplicationController
       elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
-      redirect_to check_status_and_get_url
+      redirect_to check_status_and_get_url(@step)
     else
       render :edit
     end
@@ -65,7 +65,7 @@ class Leads::TasksController < Leads::ApplicationController
   def destroy
     @task.destroy
     update_completed_tasks_rate(@step)
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
   # 「To Do リスト」にチェックを入れて「更新」ボタンを押したときに実行されるアクション
@@ -103,7 +103,7 @@ class Leads::TasksController < Leads::ApplicationController
         end
       end
     end
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
   # 「To Do リスト」で中止ボタンを押して「中止」リストに入れる処理
@@ -111,7 +111,7 @@ class Leads::TasksController < Leads::ApplicationController
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
     @task.update_attribute(:canceled_date, "#{Date.current}") if @task.canceled_date.blank?
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
   # 復活ボタンを押したときに実行されるアクション
@@ -128,7 +128,7 @@ class Leads::TasksController < Leads::ApplicationController
     else
       flash[:danger] = "#{@task.name}の更新は失敗しました。" + @task.errors.full_messages[0]
     end
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
   def edit_continue_or_destroy_step
@@ -151,7 +151,7 @@ class Leads::TasksController < Leads::ApplicationController
       update_completed_tasks_rate(@step)
       raise ActiveRecord::Rollback if errors.present?
     end
-    redirect_to check_status_and_get_url
+    redirect_to check_status_and_get_url(@step)
   end
 
 

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -37,12 +37,7 @@ class Leads::TasksController < Leads::ApplicationController
     end
     if @task.save
       update_completed_tasks_rate(@step)
-      unless $through_check_status
-        $through_check_status = true
-        redirect_to check_status_and_get_url(@step, @step)
-      else
-        redirect_to @step
-      end
+      check_status_and_redirect(@step, @step)
     else
       render :new 
     end
@@ -63,12 +58,7 @@ class Leads::TasksController < Leads::ApplicationController
       elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
-      unless $through_check_status
-        $through_check_status = true
-        redirect_to check_status_and_get_url(@step ,@step)
-      else
-        redirect_to @step
-      end
+      check_status_and_redirect(@step, @step)
     else
       render :edit
     end
@@ -77,12 +67,7 @@ class Leads::TasksController < Leads::ApplicationController
   def destroy
     @task.destroy
     update_completed_tasks_rate(@step)
-    unless $through_check_status
-      $through_check_status = true
-      redirect_to check_status_and_get_url(@step, @step)
-    else
-      redirect_to @step
-    end
+    check_status_and_redirect(@step, @step)
   end
 
   # 「To Do リスト」にチェックを入れて「更新」ボタンを押したときに実行されるアクション
@@ -120,12 +105,7 @@ class Leads::TasksController < Leads::ApplicationController
         end
       end
     end
-    unless $through_check_status
-      $through_check_status = true
-      redirect_to check_status_and_get_url(@step, @step)
-    else
-      redirect_to @step
-    end
+    check_status_and_redirect(@step, @step)
   end
 
   # 「To Do リスト」で中止ボタンを押して「中止」リストに入れる処理
@@ -133,12 +113,7 @@ class Leads::TasksController < Leads::ApplicationController
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
     @task.update_attribute(:canceled_date, "#{Date.current}") if @task.canceled_date.blank?
-    unless $through_check_status
-      $through_check_status = true
-      redirect_to check_status_and_get_url(@step, @step)
-    else
-      redirect_to @step
-    end
+    check_status_and_redirect(@step, @step)
   end
 
   # 復活ボタンを押したときに実行されるアクション
@@ -156,12 +131,7 @@ class Leads::TasksController < Leads::ApplicationController
     else
       flash[:danger] = "#{@task.name}の更新は失敗しました。" + @task.errors.full_messages[0]
     end
-    unless $through_check_status
-      $through_check_status = true
-      redirect_to check_status_and_get_url(@step, @step)
-    else
-      redirect_to @step
-    end
+    check_status_and_redirect(@step, @step)
   end
 
   def edit_continue_or_destroy_step

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -222,7 +222,7 @@ class Leads::TasksController < Leads::ApplicationController
     end
 
     def create_new_task_step_in_progress(lead, step)
-      Task.create!(step_id: step.id ,name: "new_task", status: 0, scheduled_complete_date: "#{Date.current}")
+      Task.create!(step_id: step.id ,name: "new_task", status: "not_yet", scheduled_complete_date: "#{Date.current}")
       redirect_to step_statuses_start_step_url(@step)
     end
 end

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -36,7 +36,12 @@ class Leads::TasksController < Leads::ApplicationController
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save && update_completed_tasks_rate(@step)
-      redirect_to check_status_and_get_url(@step, @step)
+      if $step_num == 0
+        $step_num += 1
+        redirect_to check_status_and_get_url(@step, @step)
+      else
+        redirect_to @step
+      end
     else
       render :new 
     end
@@ -56,7 +61,12 @@ class Leads::TasksController < Leads::ApplicationController
       elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
-      redirect_to check_status_and_get_url(@step ,@step)
+      if $step_num == 0
+        $step_num += 1
+        redirect_to check_status_and_get_url(@step ,@step)
+      else
+        redirect_to @step
+      end
     else
       render :edit
     end
@@ -65,7 +75,12 @@ class Leads::TasksController < Leads::ApplicationController
   def destroy
     @task.destroy
     update_completed_tasks_rate(@step)
-    redirect_to check_status_and_get_url(@step, @step)
+    if $step_num == 0
+      $step_num += 1
+      redirect_to check_status_and_get_url(@step, @step)
+    else
+      redirect_to @step
+    end
   end
 
   # 「To Do リスト」にチェックを入れて「更新」ボタンを押したときに実行されるアクション
@@ -103,7 +118,12 @@ class Leads::TasksController < Leads::ApplicationController
         end
       end
     end
-    redirect_to check_status_and_get_url(@step, @step)
+    if $step_num == 0
+      $step_num += 1
+      redirect_to check_status_and_get_url(@step, @step)
+    else
+      redirect_to @step
+    end
   end
 
   # 「To Do リスト」で中止ボタンを押して「中止」リストに入れる処理
@@ -111,7 +131,12 @@ class Leads::TasksController < Leads::ApplicationController
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
     @task.update_attribute(:canceled_date, "#{Date.current}") if @task.canceled_date.blank?
-    redirect_to check_status_and_get_url(@step, @step)
+    if $step_num == 0
+      $step_num += 1
+      redirect_to check_status_and_get_url(@step, @step)
+    else
+      redirect_to @step
+    end
   end
 
   # 復活ボタンを押したときに実行されるアクション
@@ -128,7 +153,12 @@ class Leads::TasksController < Leads::ApplicationController
     else
       flash[:danger] = "#{@task.name}の更新は失敗しました。" + @task.errors.full_messages[0]
     end
-    redirect_to check_status_and_get_url(@step, @step)
+    if $step_num == 0
+      $step_num += 1
+      redirect_to check_status_and_get_url(@step, @step)
+    else
+      redirect_to @step
+    end
   end
 
   def edit_continue_or_destroy_step

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -37,7 +37,7 @@ class Leads::TasksController < Leads::ApplicationController
     end
     if @task.save
       update_completed_tasks_rate(@step)
-      check_status_and_redirect(@step, @step)
+      check_status_and_redirect_to(@step, @step)
     else
       render :new 
     end
@@ -58,7 +58,7 @@ class Leads::TasksController < Leads::ApplicationController
       elsif prohibit_future(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
-      check_status_and_redirect(@step, @step)
+      check_status_and_redirect_to(@step, @step)
     else
       render :edit
     end
@@ -67,7 +67,7 @@ class Leads::TasksController < Leads::ApplicationController
   def destroy
     @task.destroy
     update_completed_tasks_rate(@step)
-    check_status_and_redirect(@step, @step)
+    check_status_and_redirect_to(@step, @step)
   end
 
   # 「To Do リスト」にチェックを入れて「更新」ボタンを押したときに実行されるアクション
@@ -105,7 +105,7 @@ class Leads::TasksController < Leads::ApplicationController
         end
       end
     end
-    check_status_and_redirect(@step, @step)
+    check_status_and_redirect_to(@step, @step)
   end
 
   # 「To Do リスト」で中止ボタンを押して「中止」リストに入れる処理
@@ -113,7 +113,7 @@ class Leads::TasksController < Leads::ApplicationController
     @task.update_attribute(:status, "canceled")
     update_completed_tasks_rate(@step)
     @task.update_attribute(:canceled_date, "#{Date.current}") if @task.canceled_date.blank?
-    check_status_and_redirect(@step, @step)
+    check_status_and_redirect_to(@step, @step)
   end
 
   # 復活ボタンを押したときに実行されるアクション
@@ -131,7 +131,7 @@ class Leads::TasksController < Leads::ApplicationController
     else
       flash[:danger] = "#{@task.name}の更新は失敗しました。" + @task.errors.full_messages[0]
     end
-    check_status_and_redirect(@step, @step)
+    check_status_and_redirect_to(@step, @step)
   end
 
   def edit_continue_or_destroy_step

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -1,2 +1,5 @@
 module StepsHelper
+  def step_name(step)
+    "<STEP#{step.order}>#{step.name}"
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,5 @@
 module TasksHelper
+  def step_name(step)
+    "<STEP#{step.order}>#{step.name}"
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,5 +1,2 @@
 module TasksHelper
-  def step_name(step)
-    "<STEP#{step.order}>#{step.name}"
-  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -13,7 +13,7 @@ class Step < ApplicationRecord
   validates :completed_date, presence: true, length: { in: 0..32 }, if: -> { status == "completed" }
   validate :completed_date_prohibit_future
   validates :completed_tasks_rate, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100}
-  validate :match_tasks_status, on: :check_tasks_status
+  #validate :match_tasks_status, on: :check_tasks_status
   enum status:[:not_yet, :inactive, :in_progress, :completed, :template] # 進捗ステータス
   
   # :orderカラムが連番であることを保証するには、最大値がレコードの数と一致する必要がある。@step.valid?(:check_order)したときのみバリデーションを実行。
@@ -27,13 +27,13 @@ class Step < ApplicationRecord
   end
   
   # タスクの:statusは、進捗のstatusに対応するstatusが必要。@step.valid?(:check_tasks_status)したときのみバリデーションを実行。
-  def match_tasks_status
-    if self.status?("in_progress") && self.tasks.not_yet.blank?
-      errors.add(:status, ":進捗中の進捗には、未のタスクが少なくとも一つ以上必要です。")
-    elsif self.status?("completed") && self.tasks.completed.blank?
-      errors.add(:status, ":完了済みの進捗には、完了済のタスクが少なくとも一つ以上必要です。")
-    end
-  end
+  #def match_tasks_status
+  #  if self.status?("in_progress") && self.tasks.not_yet.blank?
+  #    errors.add(:status, ":進捗中の進捗には、未のタスクが少なくとも一つ以上必要です。")
+  #  elsif self.status?("completed") && self.tasks.completed.blank?
+  #    errors.add(:status, ":完了済みの進捗には、完了済のタスクが少なくとも一つ以上必要です。")
+  #  end
+  #end
  
   # メソッド
   

--- a/app/views/leads/step_statuses/_index.html.erb
+++ b/app/views/leads/step_statuses/_index.html.erb
@@ -12,7 +12,7 @@
           </p>
         </td>
         <% if step.status?("not_yet") %>
-          <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, new_task: nil, button_name: "完了予定日を設定して開始する" %></td>
+          <td><%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, new_task: true, button_name: "完了予定日を設定して開始する" %></td>
         <% elsif step.status?("inactive") %>
           <td>
             <p>
@@ -43,7 +43,7 @@
             </p>
             <div id="collapseStep<%= step.id %>" class="collapse">
             	<div class="well">
-                <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, new_task: nil, button_name: "完了予定日を再設定して再開する" %>
+                <%= render 'leads/step_statuses/start', step: step, completed_id: completed_step, new_task: true, button_name: "完了予定日を再設定して再開する" %>
             	</div>
             </div>
           </td>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -38,7 +38,6 @@
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
         <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch unless @lead.status?("inactive") %>
       <% when "in_progress" %>
-        <%= $step_num = 0 %>
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
         <%= render 'leads/step_statuses/cancel', lead: @lead, step: @step, button_name: "保留" %>
       <% when "completed" %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -38,6 +38,7 @@
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
         <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch unless @lead.status?("inactive") %>
       <% when "in_progress" %>
+        <%= $step_num = 0 %>
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
         <%= render 'leads/step_statuses/cancel', lead: @lead, step: @step, button_name: "保留" %>
       <% when "completed" %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -33,7 +33,7 @@
       <%= @step.memo %><br>
       <% case @step.status %>
       <% when "not_yet" %>
-        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "開始" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
       <% when "inactive" %>
         <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
         <%= link_to "案件自体を凍結", cancel_lead_path(@lead), class: "btn btn-danger btn-sm", method: :patch unless @lead.status?("inactive") %>
@@ -41,7 +41,7 @@
         <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
         <%= render 'leads/step_statuses/cancel', lead: @lead, step: @step, button_name: "保留" %>
       <% when "completed" %>
-        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, button_name: "再開" %>
+        <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "再開" %>
       <% when "template" %>
         <button type="button" class="btn btn-info">このテンプレートを使用して新規作成</button>
       <% end %>

--- a/app/views/leads/tasks/_tasks_index.html.erb
+++ b/app/views/leads/tasks/_tasks_index.html.erb
@@ -65,7 +65,7 @@
     <div class="panel-heading">
       <p class="panel-title">
         <a data-toggle="collapse" data-parent="#accordion" href="#collapse3"><h4 style="display:inline;">済 リスト</h4></a>
-        <h5 style="display:inline;"><%= "(#{@completed_tasks_array.count}件)" %></h5>
+        <h5 style="display:inline;"><%= "(#{@completed_tasks.count}件)" %></h5>
       </p>
     </div>
     <div id="collapse3" class="panel-collapse collapse in">
@@ -73,7 +73,7 @@
         <!--p>済 リスト</p-->
         <table>
           <tbody>
-            <% @completed_tasks_array.each do |task| %>
+            <% @completed_tasks.each do |task| %>
               <tr>
                 <td><%= link_to "#{task.name}", task_path(task) %></td>
                 <td><%= l(Time.parse(task.completed_date), format: :shortdate) %></td>
@@ -89,7 +89,7 @@
     <div class="panel-heading">
       <p class="panel-title">
         <a data-toggle="collapse" data-parent="#accordion" href="#collapse4"><h4 style="display:inline;">中止 リスト</h4></a>
-        <h5 style="display:inline;"><%= "(#{@canceled_tasks_array.count}件)" %></h5>
+        <h5 style="display:inline;"><%= "(#{@canceled_tasks.count}件)" %></h5>
       </p>
     </div>
     <div id="collapse4" class="panel-collapse collapse">
@@ -97,7 +97,7 @@
         <!--p>中止 リスト</p-->
         <table>
           <tbody>
-            <% @canceled_tasks_array.each do |task| %>
+            <% @canceled_tasks.each do |task| %>
               <tr>
                 <td><%= link_to "#{task.name}", task_path(task) %></td>
                 <td><%= l(Time.parse(task.canceled_date), format: :shortdate) %></td>

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,6 +1,5 @@
 <h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
 <h4>&#9312;現在の進捗を「未」にする</h4>
-<%= $step_num %>
 <%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :patch %>
 <br>
 <h4>&#9313;現在の進捗を「進捗中」にする</h4>
@@ -10,5 +9,5 @@
 <%= button_to '更新', cancel_step_path(@step), method: :patch %>
 <br>
 <h4>&#9315;「未」のタスクをすべて「完了」にする</h4>
-<%= button_to '更新', statuses_make_all_not_yet_tasks_completed_task_path(@step), method: :patch %>
+<%= button_to '更新', complete_all_tasks_task_path(@step), method: :patch %>
 ~  

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,4 +1,4 @@
-<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
+<h3><%= step_name(@step) %>:</h3>
 <h4>&#9312;現在の進捗を「未」にする</h4>
 <%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :patch %>
 <br>

--- a/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/tasks/edit_change_status_or_complete_task.html.erb
@@ -1,4 +1,6 @@
+<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
 <h4>&#9312;現在の進捗を「未」にする</h4>
+<%= $step_num %>
 <%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :patch %>
 <br>
 <h4>&#9313;現在の進捗を「進捗中」にする</h4>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,4 +1,5 @@
 <h4>&#9312;「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
+<%= $step_num %>
 <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
 <br>
 <h4>&#9313;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,4 +1,4 @@
-<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
+<h3><%= step_name(@step) %>:</h3>
 <h4>&#9312;「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
 <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
 <br>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -4,3 +4,4 @@
 <br>
 <h4>&#9313;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
+

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,3 +1,4 @@
+<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
 <h4>&#9312;「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
 <%= $step_num %>
 <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>

--- a/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
+++ b/app/views/leads/tasks/edit_complete_or_continue_step.html.erb
@@ -1,6 +1,5 @@
 <h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
 <h4>&#9312;「完了」タスクのうち最も遅い完了日を、進捗の完了日とし、現在の進捗を「完了」とする</h4>
-<%= $step_num %>
 <%= render 'leads/step_statuses/complete', completed_step: @step, button_name: "完了" %>
 <br>
 <h4>&#9313;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,3 +1,4 @@
+<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
 <h4>&#9312;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
 <br>

--- a/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
+++ b/app/views/leads/tasks/edit_continue_or_destroy_step.html.erb
@@ -1,4 +1,4 @@
-<h3><%= "<STEP#{@step.order}>#{@step.name}" %>:</h3>
+<h3><%= step_name(@step) %>:</h3>
 <h4>&#9312;この進捗にタスクを追加し、現在の進捗を「進捗中」とする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: true, button_name: "開始" %>
 <br>

--- a/app/views/leads/tasks/index.html.erb
+++ b/app/views/leads/tasks/index.html.erb
@@ -58,7 +58,7 @@
     <h3>済 リスト</h3>
     <table>
       <tbody>
-        <% @completed_tasks_array.each do |task| %>
+        <% @completed_tasks.each do |task| %>
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.completed_date %></td>
@@ -71,7 +71,7 @@
     <h3>中止 リスト</h3>
     <table>
       <tbody>
-        <% @canceled_tasks_array.each do |task| %>
+        <% @canceled_tasks.each do |task| %>
           <tr>
             <td><%= link_to "#{task.name}", task_path(task) %></td>
             <td><%= task.canceled_date %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
         patch 'statuses_make_step_not_yet'
-       # patch 'statuses_make_all_not_yet_tasks_completed'
+       # patch 'complete_all_tasks'
       end
       resources :tasks do
         member do
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
           get 'edit_continue_or_destroy_step'
           get 'edit_complete_or_continue_step'
           get 'edit_change_status_or_complete_task'
-          patch 'statuses_make_all_not_yet_tasks_completed'
+          patch 'complete_all_tasks'
         end
       end
     end


### PR DESCRIPTION
## やったこと
<主な変更点>
どのようなtask操作、step操作をしたとしても、進捗中の進捗には「未」のタスクが存在するように、完了済の進捗には「未」タスクが無く、「完了済み」のタスクが存在するようにしました。
<細かい変更点>
check_status_and_get_urlメソッドに２つの引数を追加しました。
status_make_all_not_yet_tasks_completeをより短いcomplete_all_tasksに変更しました。
completed_tasks_arrayをcompleted_tasksに変更、canceled_tasks_arrayをcanceled_tasksに変更しました。
## やらないこと
stepとtaskの同時フォーム更新。new_taskを生成するときにフォームに飛ばすこと。
## できるようになること(ユーザ目線)
taskの状態を保つようにユーザーを誘導するようにしました。
## できなくなること(ユーザ目線)
taskの状態を不正な状態にすること。
## 動作確認
taskのCRUD,stepのCRUD、taskのチェックボックス、中止ボタン、復活ボタンを押したとき正しく動作すること。
stepの開始ボタン、完了ボタン、保留ボタン、再開ボタン、直接編集、案件自体を凍結-再開を押したときに正しく動作すること。
## その他
step完了時に無限ループになることを回避するために、$through_check_status変数を導入しました。