### PR TITLE
進捗完了予定日変更通知を確認するロジック作成

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -5,7 +5,7 @@ class Leads::StepsController < Leads::ApplicationController
   before_action :set_steps, only: %i(show)
   # フィルター（アクセス権限）
   before_action :only_same_company_id?
-  before_action :correct_user, except: %i(index show change_limit_chack)
+  before_action :correct_user, except: %i(index show change_limit_check)
   # 後処理
   # after_action :sort_order, only: %i(destroy index)
 
@@ -98,16 +98,15 @@ class Leads::StepsController < Leads::ApplicationController
   end
 
   # Stepの期限変更通知をfalseに更新
-  def change_limit_chack
+  def change_limit_check
     if @user.superior_id == current_user.id
       @step.update(notice_change_limit: false)
       @lead.update(notice_change_limit: false) if @lead.steps.where(notice_change_limit: true).blank?
       flash[:success] = "確認しました。"
-      redirect_to @step
     else
-      flash.now[:danger] = "確認処理に失敗しました。"
-      render :show
+      flash[:danger] = "確認処理に失敗しました。"
     end
+    redirect_to @step
   end
 
   private

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,7 @@
 class NotificationsController < Users::ApplicationController
   before_action :set_users
   before_action :notice
-
+  
   # superior_idに指定されたユーザー視点の通知
   def notice
     # 新規作成時の通知
@@ -55,7 +55,8 @@ class NotificationsController < Users::ApplicationController
   def index
   end
 
-  def update
+  # 新規作成時通知をfalseに更新
+  def update_create
     user = @active_users.find(params[:id])
     leads = user.leads.in_progress
     ActiveRecord::Base.transaction do

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,6 +4,8 @@ class NotificationsController < Users::ApplicationController
   
   # superior_idに指定されたユーザー視点の通知
   def notice
+    # 入居予定日に近づいてる自分の案件の通知
+    @mystep_limit_notices = []
     # 新規作成時の通知
     @create_notices_list = [] # ユーザー毎に取得して配列に格納
     @create_notices_user_num = [] # 案件の担当ユーザーを取得
@@ -16,6 +18,12 @@ class NotificationsController < Users::ApplicationController
     @step_limit_notices_list = []
     @step_limit_notices_user_num = []
     @step_limit_notices_total_count = 0
+    # 自分の案件の通知取得ロジック
+    current_user.leads.in_progress.each do |lead|
+      if lead.steps.todo.where("scheduled_complete_date <= ?", current_user.limit_date).present?
+        @mystep_limit_notices.push(lead)
+      end
+    end
     # 企業内の全ユーザーから通知送信先がcurrent_user.id,statusがactiveのユーザーに絞る
     @active_users = @users.where(status: "active")
                           .where(superior_id: current_user.id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,13 +28,6 @@ class UsersController < NotificationsController
   end
 
   def show
-    # 入居予定日に近づいてる案件の通知
-    @mystep_limit_notices = []
-    @user.leads.in_progress.each do |lead|
-      if lead.steps.todo.where("scheduled_complete_date <= ?", @user.limit_date).present?
-        @mystep_limit_notices.push(lead)
-      end
-    end
   end
 
   def destroy

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -14,6 +14,7 @@ class Step < ApplicationRecord
   validate :completed_date_prohibit_future
   validates :completed_tasks_rate, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100}
   #validate :match_tasks_status, on: :check_tasks_status
+  validates :notice_change_limit, inclusion: { in: [true, false] }
   enum status:[:not_yet, :inactive, :in_progress, :completed, :template] # 進捗ステータス
   
   # :orderカラムが連番であることを保証するには、最大値がレコードの数と一致する必要がある。@step.valid?(:check_order)したときのみバリデーションを実行。

--- a/app/views/leads/steps/_steps_notice.html.erb
+++ b/app/views/leads/steps/_steps_notice.html.erb
@@ -1,0 +1,8 @@
+<% if @steps_notice_list.present? %>
+  <% @steps_notice_list.each do |step| %>
+    <p>
+      <%= step.name %>
+      <%= link_to "確認", change_limit_chack_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"} %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/leads/steps/_steps_notice.html.erb
+++ b/app/views/leads/steps/_steps_notice.html.erb
@@ -2,7 +2,7 @@
   <% @steps_notice_list.each do |step| %>
     <p>
       <%= step.name %>
-      <%= link_to "確認", change_limit_chack_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"} %>
+      <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"} %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -1,5 +1,6 @@
 <p id="notice"><%= notice %></p>
 
+<%= render 'steps_notice' %>
 <%= render partial: 'leads/leads/lead_show' %>
 <%= render partial: 'leads/steps/steps_index' %>
 
@@ -192,4 +193,3 @@
   <strong>Completed tasks rate:</strong>
   <%= @step.completed_tasks_rate %>
 </p>
-

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,5 +1,5 @@
 <%# 全通知の有無で分岐 %>
-<% if @create_notices_user_num.present? && @limit_change_notices_user_num.present? && @step_limit_notices_user_num.present? && @mystep_limit_notices.present? %>
+<% if @create_notices_user_num.present? || @limit_change_notices_user_num.present? || @step_limit_notices_user_num.present? || @mystep_limit_notices.present? %>
   <% if @create_notices_user_num.present? %>
     <h3>
       登録時通知

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -21,7 +21,7 @@
 
       <div id="collapse<%= i %>" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
         <div class="card-body">
-          <%= link_to "確認", notices_update_path(user_leads.first.user_id), method: :patch %>
+          <%= link_to "確認", notices_update_create_path(user_leads.first.user_id), method: :patch %>
           <table class="table table-hover">
             <thead>
               <tr>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,113 +1,144 @@
-<% if @create_notices_user_num.present? %>
-  <h3>
-    登録時通知
-    <%= @create_notices_user_num.count %>人
-    <%= @create_notices_total_count %>件
-  </h3>
-  <% @create_notices_list.each_with_index do |user_leads, i| %>
-    <div class="accordion" id="accordionExample">
-      <div class="card">
-        <div class="card-header" id="headingOne">
-          <div class="mb-0">
-            <div>
-              <%= user_name(user_leads.first.user_id) %>
-              <span class="btn btn-link text-left" type="button" data-toggle="collapse" data-target="#collapse<%= i %>" aria-expanded="true" aria-controls="collapse<%= i %>">
-                :<%= user_leads.count %>件
-              </span>
+<%# 全通知の有無で分岐 %>
+<% if @create_notices_user_num.present? && @limit_change_notices_user_num.present? && @step_limit_notices_user_num.present? && @mystep_limit_notices.present? %>
+  <% if @create_notices_user_num.present? %>
+    <h3>
+      登録時通知
+      <%= @create_notices_user_num.count %>人
+      <%= @create_notices_total_count %>件
+    </h3>
+    <% @create_notices_list.each_with_index do |user_leads, i| %>
+      <div class="accordion" id="accordionExample">
+        <div class="card">
+          <div class="card-header" id="headingOne">
+            <div class="mb-0">
+              <div>
+                <%= user_name(user_leads.first.user_id) %>
+                <span class="btn btn-link text-left" type="button" data-toggle="collapse" data-target="#collapse<%= i %>" aria-expanded="true" aria-controls="collapse<%= i %>">
+                  :<%= user_leads.count %>件
+                </span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div id="collapse<%= i %>" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
-        <div class="card-body">
-          <%= link_to "確認", notices_update_create_path(user_leads.first.user_id), method: :patch %>
-          <table class="table table-hover">
-            <thead>
-              <tr>
-                <th width="5%">申込日</th>
-                <th width="20%">部屋名:部屋番号</th>
-                <th width="10%">お客様名</th>
-                <th width="5%">詳細</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% user_leads.each do |lead| %>
+        <div id="collapse<%= i %>" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+          <div class="card-body">
+            <%= link_to "確認", notices_update_create_path(user_leads.first.user_id), method: :patch %>
+            <table class="table table-hover">
+              <thead>
                 <tr>
-                  <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
-                  <td><%= room_name_num(lead) %></td>
-                  <td><%= lead.customer_name %></td>
-                  <td><%= link_to "詳細", step_path(lead) %></td>
+                  <th width="5%">申込日</th>
+                  <th width="20%">部屋名:部屋番号</th>
+                  <th width="10%">お客様名</th>
+                  <th width="5%">詳細</th>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                <% user_leads.each do |lead| %>
+                  <tr>
+                    <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
+                    <td><%= room_name_num(lead) %></td>
+                    <td><%= lead.customer_name %></td>
+                    <td><%= link_to "詳細", step_path(lead) %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
-<% end %>
 
-<% if @limit_change_notices_user_num.present? %>
-  <h3>
-    変更時通知
-    <%= @limit_change_notices_user_num.count %>人
-    <%= @limit_change_notices_total_count %>件
-  </h3>
-  <% @limit_change_notices_list.each do |user_leads| %>
-    <h4><%= user_name(user_leads.first.user_id) %></h4>
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th width="5%">申込日</th>
-          <th width="20%">部屋名:部屋番号</th>
-          <th width="10%">お客様名</th>
-          <th width="30%">メモ</th>
-          <th width="5%">詳細</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% user_leads.each do |lead| %>
+  <% if @limit_change_notices_user_num.present? %>
+    <h3>
+      変更時通知
+      <%= @limit_change_notices_user_num.count %>人
+      <%= @limit_change_notices_total_count %>件
+    </h3>
+    <% @limit_change_notices_list.each do |user_leads| %>
+      <h4><%= user_name(user_leads.first.user_id) %></h4>
+      <table class="table table-hover">
+        <thead>
           <tr>
-            <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
-            <td><%= room_name_num(lead) %></td>
-            <td><%= lead.customer_name %></td>
-            <td><%= lead.memo %></td>
-            <td><%= link_to "詳細", step_path(lead) %></td>
+            <th width="5%">申込日</th>
+            <th width="20%">部屋名:部屋番号</th>
+            <th width="10%">お客様名</th>
+            <th width="30%">メモ</th>
+            <th width="5%">詳細</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% user_leads.each do |lead| %>
+            <tr>
+              <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
+              <td><%= room_name_num(lead) %></td>
+              <td><%= lead.customer_name %></td>
+              <td><%= lead.memo %></td>
+              <td><%= link_to "詳細", step_path(lead) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   <% end %>
-<% end %>
 
-<% if @step_limit_notices_user_num.present? %>
-  <h3>
-    期限通知
-    <%= @step_limit_notices_user_num.count %>人
-    <%= @step_limit_notices_total_count %>件
-  </h3>
-  <% @step_limit_notices_list.each do |user_leads| %>
-    <h4><%= user_name(user_leads.first.user_id) %></h4>
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th width="5%">申込日</th>
-          <th width="20%">部屋名:部屋番号</th>
-          <th width="10%">お客様名</th>
-          <th width="5%">詳細</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% user_leads.each do |lead| %>
+  <% if @step_limit_notices_user_num.present? %>
+    <h3>
+      期限通知
+      <%= @step_limit_notices_user_num.count %>人
+      <%= @step_limit_notices_total_count %>件
+    </h3>
+    <% @step_limit_notices_list.each do |user_leads| %>
+      <h4><%= user_name(user_leads.first.user_id) %></h4>
+      <table class="table table-hover">
+        <thead>
           <tr>
-            <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
-            <td><%= room_name_num(lead) %></td>
-            <td><%= lead.customer_name %></td>
-            <td><%= link_to "詳細", step_path(lead) %></td>
+            <th width="5%">申込日</th>
+            <th width="20%">部屋名:部屋番号</th>
+            <th width="10%">お客様名</th>
+            <th width="5%">詳細</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% user_leads.each do |lead| %>
+            <tr>
+              <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
+              <td><%= room_name_num(lead) %></td>
+              <td><%= lead.customer_name %></td>
+              <td><%= link_to "詳細", step_path(lead) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   <% end %>
+
+  <% if @mystep_limit_notices.present? %>
+    <h3>
+      自分の通知:<%= @mystep_limit_notices.count %>件
+    </h3>
+    <table class="table table-hover">
+        <thead>
+          <tr>
+            <th width="5%">申込日</th>
+            <th width="20%">部屋名:部屋番号</th>
+            <th width="10%">お客様名</th>
+            <th width="5%">詳細</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @mystep_limit_notices.each do |lead| %>
+            <tr>
+              <td><%= l(Time.parse(lead.created_date), format: :shortdate) %></td>
+              <td><%= room_name_num(lead) %></td>
+              <td><%= lead.customer_name %></td>
+              <td><%= link_to "詳細", step_path(lead) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+  <% end %>
+<% else %>
+  <h3>現在の通知はありません</h3>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
         patch 'statuses_make_step_not_yet'
        # patch 'complete_all_tasks'
-        patch 'change_limit_chack'
+        patch 'change_limit_check'
       end
       resources :tasks do
         member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,8 @@ Rails.application.routes.draw do
     match 'users/:id', to: 'users/registrations#update', via: [:patch, :put], as: :other_user_registration
   end
   get "users/:id/notices", to: "notifications#index", as: :notices
-  patch "users/:id/notices", to: "notifications#update", as: :notices_update
-  
+  patch "users/:id/notices_update_create", to: "notifications#update_create", as: :notices_update_create
+
   # 案件フォルダ群（Leads::ApplicationControllerを継承）lead, step, task関連
   resources :leads, shallow: true, module: 'leads' do
     member do
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
         patch 'statuses_make_step_not_yet'
        # patch 'complete_all_tasks'
+        patch 'change_limit_chack'
       end
       resources :tasks do
         member do

--- a/db/migrate/20200830064219_create_steps.rb
+++ b/db/migrate/20200830064219_create_steps.rb
@@ -9,6 +9,7 @@ class CreateSteps < ActiveRecord::Migration[5.2]
       t.string :completed_date, null: false, default: ""
       t.string :canceled_date, null: false, default: ""
       t.integer :completed_tasks_rate, null: false, default: 0
+      t.boolean :notice_change_limit, null: false, default: false
 
       t.references :lead, foreign_key: true
       

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_123021) do
     t.string "completed_date", default: "", null: false
     t.string "canceled_date", default: "", null: false
     t.integer "completed_tasks_rate", default: 0, null: false
+    t.boolean "notice_change_limit", default: false, null: false
     t.integer "lead_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,6 +101,7 @@ puts "Userテスト用サンプルレコード作成完了"
         status: "in_progress",
         order: 1,
         scheduled_complete_date: (Date.current + 3).to_s,
+        # notice_change_limit: true # 完了予定日変更時通知
       )
     end
     puts "「サンプル太郎(#{j})」の案件作成完了"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,7 +101,7 @@ puts "Userテスト用サンプルレコード作成完了"
         status: "in_progress",
         order: 1,
         scheduled_complete_date: (Date.current + 3).to_s,
-        # notice_change_limit: true # 完了予定日変更時通知
+        notice_change_limit: true, # 完了予定日変更時通知
       )
     end
     puts "「サンプル太郎(#{j})」の案件作成完了"


### PR DESCRIPTION
## やったこと

- stepモデルにnotice_change_limitカラムを追加

- validatesをleadモデルのnotice_change_limitと同じに設定

- 進捗完了予定日変更通知を確認するロジックを作成

- (new)自分が担当するの案件の進捗の遅れを通知するロジックと表示部分

## やらないこと
viewの調整
## できるようになること(ユーザ目線)
進捗完了予定日変更通知を確認して件数を減らす
## 動作確認
手動テストを行い、案件詳細ページから通知を確認して通知を消す動作の確認をした。
## その他
これで通知の実装はviewの改修を残すのみですが、
フェーズ１で必要なコーディングはこれで済んだと思っています。
後は入念なテスト、メンバーのカバーに回る予定です。