### PR TITLE
完了予定日と完了日に過去の日付を入力するとフラッシュメッセージを表示する

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -21,7 +21,7 @@ class Leads::ApplicationController < Users::ApplicationController
         flash[:success] = "#{step.name}は既に進捗中です。"
       else
         flash[:success] = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "", canceled_date: "")
-        if prohibit_future(step.scheduled_complete_date)
+        if prohibit_past(step.scheduled_complete_date)
           flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
         end
       end
@@ -33,7 +33,7 @@ class Leads::ApplicationController < Users::ApplicationController
       # 新規タスク作成
       if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
         @task = step.tasks.create(task_simple_params)
-        if prohibit_future(@task.scheduled_complete_date)
+        if prohibit_past(@task.scheduled_complete_date)
           flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
         end
       end
@@ -254,7 +254,7 @@ class Leads::ApplicationController < Users::ApplicationController
   end
 
   # day空でなく、今日より前ならtrue
-  def prohibit_future(day)
+  def prohibit_past(day)
     day.blank? ? false : Date.parse(day) < Date.current
   end
 

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -21,6 +21,9 @@ class Leads::ApplicationController < Users::ApplicationController
         flash[:success] = "#{step.name}は既に進捗中です。"
       else
         flash[:success] = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "", canceled_date: "")
+        if prohibit_future(step.scheduled_complete_date)
+          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
+        end
       end
       # 完了する進捗がある場合の処理
       if params[:completed_id].present?
@@ -31,7 +34,7 @@ class Leads::ApplicationController < Users::ApplicationController
       if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
         @task = step.tasks.create(task_simple_params)
         if prohibit_future(@task.scheduled_complete_date)
-          flash[:danger] = "タスクの完了予定日に過去の日付を入力しようとしています。"
+          flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
         end
       end
       # 案件を再開する場合の処理

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -21,9 +21,7 @@ class Leads::ApplicationController < Users::ApplicationController
         flash[:success] = "#{step.name}は既に進捗中です。"
       else
         flash[:success] = "#{step.name}を開始しました。" if step.update_attributes(status: "in_progress", scheduled_complete_date: scheduled_complete_date, completed_date: "", canceled_date: "")
-        if prohibit_past(step.scheduled_complete_date)
-          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
-        end
+        flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。" if prohibit_past(step.scheduled_complete_date)
       end
       # 完了する進捗がある場合の処理
       if params[:completed_id].present?
@@ -33,9 +31,7 @@ class Leads::ApplicationController < Users::ApplicationController
       # 新規タスク作成
       if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
         @task = step.tasks.create(task_simple_params)
-        if prohibit_past(@task.scheduled_complete_date)
-          flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
-        end
+        flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
       end
       # 案件を再開する場合の処理
       start_lead(lead) unless lead.status?("in_progress")

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -184,10 +184,22 @@ class Leads::StepsController < Leads::ApplicationController
         # 更新処理（バリデーションなし）
         prepare_order(step.order, params[:step][:order].to_i)
         step.update(step_params)
+        if prohibit_past(step.scheduled_complete_date)
+          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
+        end
+        if prohibit_past(step.completed_date)
+          flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。"
+        end
         lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
         # 新規タスク作成
         if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
           @task =Task.create(task_params)
+          if prohibit_past(@task.scheduled_complete_date)
+            flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
+          end
+          if prohibit_past(@task.completed_date)
+            flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。"
+          end
         end
         # 矛盾を解消
         check_status_inactive_or_not(step)

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -48,6 +48,12 @@ class Leads::StepsController < Leads::ApplicationController
   def create
     @step = @lead.steps.new(step_params)
     @task = @step.tasks.new(task_params)
+    if prohibit_past(@task.scheduled_complete_date)
+      flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
+    end
+    if prohibit_past(@task.completed_date)
+      flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。"
+    end
     if save_step_errors(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を作成しました。"
       if params[:step][:status].present? && params[:step][:status] == "completed"
@@ -139,6 +145,12 @@ class Leads::StepsController < Leads::ApplicationController
         # 作成処理（バリデーションなし）
         prepare_order(lead.steps.count + 1, step.order)
         errors << step.errors.full_messages unless step.save
+        if prohibit_past(step.scheduled_complete_date)
+          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
+        end
+        if prohibit_past(step.completed_date)
+          flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。"
+        end
         # 完了する進捗がある場合の処理
         if params[:step][:completed_id].present?
           @completed_step = Step.find(params[:step][:completed_id]) # 完了処理に失敗したら、改めてオブジェクトを渡す必要があるのでインスタンス変数を使用。

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -48,12 +48,8 @@ class Leads::StepsController < Leads::ApplicationController
   def create
     @step = @lead.steps.new(step_params)
     @task = @step.tasks.new(task_params)
-    if prohibit_past(@task.scheduled_complete_date)
-      flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
-    end
-    if prohibit_past(@task.completed_date)
-      flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。"
-    end
+    flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
+    flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。" if prohibit_past(@task.completed_date)
     if save_step_errors(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を作成しました。"
       if params[:step][:status].present? && params[:step][:status] == "completed"
@@ -145,12 +141,8 @@ class Leads::StepsController < Leads::ApplicationController
         # 作成処理（バリデーションなし）
         prepare_order(lead.steps.count + 1, step.order)
         errors << step.errors.full_messages unless step.save
-        if prohibit_past(step.scheduled_complete_date)
-          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
-        end
-        if prohibit_past(step.completed_date)
-          flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。"
-        end
+        flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。" if prohibit_past(step.scheduled_complete_date)
+        flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。" if prohibit_past(step.completed_date)
         # 完了する進捗がある場合の処理
         if params[:step][:completed_id].present?
           @completed_step = Step.find(params[:step][:completed_id]) # 完了処理に失敗したら、改めてオブジェクトを渡す必要があるのでインスタンス変数を使用。
@@ -184,22 +176,14 @@ class Leads::StepsController < Leads::ApplicationController
         # 更新処理（バリデーションなし）
         prepare_order(step.order, params[:step][:order].to_i)
         step.update(step_params)
-        if prohibit_past(step.scheduled_complete_date)
-          flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。"
-        end
-        if prohibit_past(step.completed_date)
-          flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。"
-        end
+        flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。" if prohibit_past(step.scheduled_complete_date)
+        flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。" if prohibit_past(step.completed_date)
         lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
         # 新規タスク作成
         if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
           @task =Task.create(task_params)
-          if prohibit_past(@task.scheduled_complete_date)
-            flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。"
-          end
-          if prohibit_past(@task.completed_date)
-            flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。"
-          end
+          flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
+          flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。" if prohibit_past(@task.completed_date)
         end
         # 矛盾を解消
         check_status_inactive_or_not(step)

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -33,9 +33,7 @@ class Leads::TasksController < Leads::ApplicationController
 
   def create
     @task = Task.new(task_params)
-    if prohibit_past(@task.scheduled_complete_date)
-      flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-    end
+    flash[:danger] = "完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
     if @task.save
       update_completed_tasks_rate(@step)
       check_status_and_redirect_to(@step, @step, nil)
@@ -52,13 +50,8 @@ class Leads::TasksController < Leads::ApplicationController
       @task.date_blank_then_today("completed")
       # 中止にした日が空なら今日の日付を入れる
       @task.date_blank_then_today("canceled")
-      if prohibit_past(@task.scheduled_complete_date) && prohibit_past(@task.completed_date)
-        flash[:danger] = "完了予定日と完了日に過去の日付を入力しようとしています。"
-      elsif prohibit_past(@task.scheduled_complete_date)
-        flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-      elsif prohibit_past(@task.completed_date)
-        flash[:danger] = "完了日に過去の日付を入力しようとしています。"
-      end
+      flash[:danger] = "#{flash[:danger]}完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
+      flash[:danger] = "#{flash[:danger]}完了日に過去の日付を入力しようとしています。" if prohibit_past(@task.completed_date)
       check_status_and_redirect_to(@step, @step, nil)
     else
       render :edit
@@ -124,9 +117,7 @@ class Leads::TasksController < Leads::ApplicationController
   # 復活ボタンを押した画面から更新ボタンを押した後の処理
   def update_revive_from_canceled_list
     if @task.update_attributes(revive_from_canceled_list_params)
-      if prohibit_past(@task.scheduled_complete_date)
-        flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-      end
+      flash[:danger] = "完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
       @task.update_attribute(:status, "not_yet")
       update_completed_tasks_rate(@step)
     else

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -33,7 +33,7 @@ class Leads::TasksController < Leads::ApplicationController
 
   def create
     @task = Task.new(task_params)
-    if prohibit_future(@task.scheduled_complete_date)
+    if prohibit_past(@task.scheduled_complete_date)
       flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
     end
     if @task.save
@@ -52,11 +52,11 @@ class Leads::TasksController < Leads::ApplicationController
       @task.date_blank_then_today("completed")
       # 中止にした日が空なら今日の日付を入れる
       @task.date_blank_then_today("canceled")
-      if prohibit_future(@task.scheduled_complete_date) && prohibit_future(@task.completed_date)
+      if prohibit_past(@task.scheduled_complete_date) && prohibit_past(@task.completed_date)
         flash[:danger] = "完了予定日と完了日に過去の日付を入力しようとしています。"
-      elsif prohibit_future(@task.scheduled_complete_date)
+      elsif prohibit_past(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
-      elsif prohibit_future(@task.completed_date)
+      elsif prohibit_past(@task.completed_date)
         flash[:danger] = "完了日に過去の日付を入力しようとしています。"
       end
       check_status_and_redirect_to(@step, @step, nil)
@@ -124,7 +124,7 @@ class Leads::TasksController < Leads::ApplicationController
   # 復活ボタンを押した画面から更新ボタンを押した後の処理
   def update_revive_from_canceled_list
     if @task.update_attributes(revive_from_canceled_list_params)
-      if prohibit_future(@task.scheduled_complete_date)
+      if prohibit_past(@task.scheduled_complete_date)
         flash[:danger] = "完了予定日に過去の日付を入力しようとしています。"
       end
       @task.update_attribute(:status, "not_yet")


### PR DESCRIPTION
## やったこと
①app/controllers/leads/application.rbのstart_stepで完了予定日に過去の日付を入力するとフラッシュメッセージを表示して警告する
②新規進捗（同時にタスク）作成時、完了予定日と完了日に過去の日付を入力するとフラッシュメッセージを表示して警告する
③進捗（同時にタスク）直接編集時、完了予定日と完了日に過去の日付を入力するとフラッシュメッセージを表示して警告する
## やらないこと
無し。
## できるようになること(ユーザ目線)
完了予定日と完了日に過去の日付を入力すると、フラッシュメッセージを受け取り確認することができる。
## できなくなること(ユーザ目線)
無し。
## 動作確認
app/controllers/leads/application.rbのstart_stepで進捗生成時、タスク生成時、新規進捗作成時、進捗直接編集時に完了予定日と完了日に過去の日付を入力するとフラッシュメッセージが表示されることを確認。
## その他
過去にprohibit_futureという名前のメソッドを作って、タスクの生成編集などで使っていましたが、名称の適切性から、prohibit_pastという名前に変更しました。
