### PR TITLE
Refactering flash-message and Set template-validation

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -182,6 +182,13 @@ class Leads::ApplicationController < Users::ApplicationController
     
   end
   
+  # 案件がテンプレ―トとして作成された場合、チェックを入れる
+  def check_status_template_or_not(lead)
+    if lead.status?("template") && !lead.template
+      lead.update_attribute(:template, true)
+    end
+  end
+  
   # leadの進捗率を更新
   def update_steps_rate(lead)
     lead.update_attribute(:steps_rate, calculate_rate(lead.steps.completed.count, lead.steps.todo.count))
@@ -262,9 +269,9 @@ class Leads::ApplicationController < Users::ApplicationController
       when 0
         flash.now[:danger] = "該当する案件はありません。検索条件を見直しください。"
       when leads.where(user_id: user_ids_all).count
-        flash.now[:success] = "全件表示中（全#{leads_count}件）"
+        flash.now[:info] = "全件表示中（全#{leads_count}件）"
       else
-        flash.now[:success] = "#{leads_count}件ヒットしました。"
+        flash.now[:info] = "#{leads_count}件ヒットしました。"
       end
       @leads = @leads.page(params[:page])
     end

--- a/app/controllers/leads/leads_controller.rb
+++ b/app/controllers/leads/leads_controller.rb
@@ -12,12 +12,10 @@ class Leads::LeadsController < Leads::ApplicationController
   before_action :correct_or_admin_user, only: %i(destroy)
 
   # GET /leads
-  # GET /leads.json
   def index
   end
 
   # GET /leads/1
-  # GET /leads/1.json
   def show
   end
 
@@ -36,7 +34,6 @@ class Leads::LeadsController < Leads::ApplicationController
   end
 
   # POST /leads
-  # POST /leads.json
   def create
     @lead = current_user.leads.new(lead_params)
     if save_lead_errors(@lead).blank?
@@ -51,19 +48,15 @@ class Leads::LeadsController < Leads::ApplicationController
   end
 
   # PATCH/PUT /leads/1
-  # PATCH/PUT /leads/1.json
   def update
-    respond_to do |format|
-      if @lead.update(lead_params) && update_steps_rate(@lead)
-        check_status_inactive_or_not(@lead)
-        check_status_completed_or_not(@lead, nil)
-        @lead.update_attribute(:notice_change_limit, true) if @lead.saved_change_to_scheduled_resident_date? || @lead.saved_change_to_scheduled_payment_date?
-        format.html { redirect_to step_path(working_step_in(@lead)), notice: 'Lead was successfully updated.' }
-        format.json { render :show, status: :ok, location: @lead }
-      else
-        format.html { render :edit }
-        format.json { render json: @lead.errors, status: :unprocessable_entity }
-      end
+    if update_lead_errors(@lead).blank?
+      @lead.update_attribute(:notice_change_limit, true) if @lead.saved_change_to_scheduled_resident_date? || @lead.saved_change_to_scheduled_payment_date?
+      flash[:success] = "案件を編集しました。#{flash[:success]}"
+      redirect_to step_url(working_step_in(@lead))
+    else
+      flash.delete(:success)
+      flash.now[:danger] = "#{@lead.errors.full_messages.first}" if @lead.errors.present?
+      render :edit
     end
   end
 
@@ -84,10 +77,8 @@ class Leads::LeadsController < Leads::ApplicationController
   # DELETE /leads/1.json
   def destroy
     @lead.destroy
-    respond_to do |format|
-      format.html { redirect_to leads_url, notice: 'Lead was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    flash[:success] = "案件(#{@lead.customer_name}様/#{@lead.room_name}-#{@lead.room_num}号室)を削除しました。#{flash[:success]}"
+    redirect_to leads_url
   end
 
   private
@@ -147,13 +138,13 @@ class Leads::LeadsController < Leads::ApplicationController
             # （ある程度決まったプロセスなのに一から進捗をつくるのはUXとして非現実的。）↓は仮。
             lead.steps.create!(
               name: "進捗(仮)",
-              status: 2,
+              status: lead.status,
               order: 1,
               scheduled_complete_date: "#{Date.current}",
             )
           end
-    
           # 矛盾を解消
+          check_status_template_or_not(lead)
           check_status_inactive_or_not(lead)
           check_status_completed_or_not(lead, nil)
           # バリデーション確認
@@ -166,4 +157,21 @@ class Leads::LeadsController < Leads::ApplicationController
       errors.presence || nil
     end
     
+    # アップデート処理
+    def update_lead_errors(lead)
+      errors = []
+      ActiveRecord::Base.transaction do
+        # 作成処理（バリデーションなし）
+        lead.update(lead_params)
+        # 矛盾を解消
+        check_status_template_or_not(lead)
+        check_status_inactive_or_not(lead)
+        check_status_completed_or_not(lead, nil)
+        # バリデーション確認
+        errors << lead.errors.full_messages if lead.invalid?(:check_steps_status)
+        raise ActiveRecord::Rollback if errors.present?
+      end
+      errors.presence || nil
+    end
+
 end

--- a/app/models/lead.rb
+++ b/app/models/lead.rb
@@ -36,6 +36,10 @@ class Lead < ApplicationRecord
       errors.add(:status, ":完了済の案件には、完了済の進捗が少なくとも一つ以上必要です。")
     elsif self.status?("inactive") && self.steps.inactive.blank?
       errors.add(:status, ":凍結中の案件には、凍結中の進捗が必要です。")
+    elsif self.status?("template") && self.steps.template.blank?
+      errors.add(:status, ":テンプレートの案件には、テンプレートの進捗が少なくとも一つ以上必要です。")
+    elsif !self.status?("template") && self.steps.template.present?
+      errors.add(:status, ":通常の案件に、テンプレートの進捗を作成することはできません。")
     end
   end
   

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -21,7 +21,7 @@ class Step < ApplicationRecord
   def order_is_serial_number
     steps_of_same_lead = Step.where(lead_id: self.lead_id)
     if steps_of_same_lead.present?
-      unless steps_of_same_lead.pluck(:order).max <= steps_of_same_lead.count
+      if steps_of_same_lead.pluck(:order).max > steps_of_same_lead.count
         errors.add(:order, "が「1から始まる連番」になっていません。")
       end
     end

--- a/app/views/leads/leads/_form.html.erb
+++ b/app/views/leads/leads/_form.html.erb
@@ -70,13 +70,13 @@
 ----------------------------------------------------------------
 
   <div class="field">
-    <%= form.label :template %>
-    <%= form.check_box :template %>←テンプレートにする場合はチェック
+    <%= form.check_box :template %>←ステータスに関わらずテンプレートとして使用する。
   </div>
 
   <div class="field">
     <%= form.label :template_name %>
-    <%= form.text_field :template_name %>
+    <%= form.text_field :template_name %><br>
+     ↑ ステータスがテンプレートまたはテンプレートにチェックで入力必須。
   </div>
 
   <div class="actions">

--- a/app/views/leads/leads/edit.html.erb
+++ b/app/views/leads/leads/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Lead</h1>
+<h1>案件の編集</h1>
 
 <%= render 'form', lead: @lead %>
 

--- a/app/views/leads/steps/new.html.erb
+++ b/app/views/leads/steps/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Step</h1>
+<h1>進捗の新規作成</h1>
 
 <%= render 'form', lead: @lead, step: @step %>
 

--- a/app/views/shared/_header_main.html.erb
+++ b/app/views/shared/_header_main.html.erb
@@ -25,9 +25,6 @@
         <li class="nav-item">
           <%= link_to "案件一覧", leads_path, class: "nav-link active" %>
         </li>
-        <li class="nav-item">
-          <%= link_to "テンプレート一覧", template_index_leads_path, class: "nav-link active" %>
-        </li>
       </ul>
     </div>
   </nav>

--- a/app/views/shared/_header_sub.html.erb
+++ b/app/views/shared/_header_sub.html.erb
@@ -2,11 +2,15 @@
   <nav class="nav nav-underline">
     <a class="nav-link active" href="#">Dashboard</a>
     <a class="nav-link" href="#">
-      Friends
-      <span class="badge badge-pill bg-light align-text-bottom">27</span>
+      <%= link_to "進行中の案件数", leads_path(user_searchword: current_user.id), class: "nav-link active" %>
+      <span class="badge badge-pill bg-light align-text-bottom"><%= link_to "#{Lead.where(user_id: current_user.id).count}", leads_path(user_searchword: current_user.id), class: "nav-link active" %></span>
     </a>
-    <a class="nav-link" href="#">Explore</a>
-    <a class="nav-link" href="#">Suggestions</a>
+    <a class="nav-link" href="#">
+      <%= link_to "案件新規作成", new_lead_path, class: "nav-link active" %>
+    </a>
+    <a class="nav-link" href="#">
+      <%= link_to "案件をテンプレートから作成", template_index_leads_path, class: "nav-link active" %>
+    </a>
     <a class="nav-link" href="#">Link</a>
     <a class="nav-link" href="#">Link</a>
     <a class="nav-link" href="#">Link</a>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -145,7 +145,7 @@ end
     lead_id: 1,
     name: "進捗#{i+2}",
     memo: "進捗#{i+2}のメモ",
-    status: 0,
+    status: "not_yet",
     order: i+2,
     scheduled_complete_date: (Date.current + 3 + 3*i).to_s,
   )


### PR DESCRIPTION
## やったこと
* テンプレートのバリデーションを追加
* フラッシュメッセージのリファクタリング（noticeをflashへ）
* サブヘッダーをこんな感じにしてみましたがいかがでしょうか。
（Dashbordやlinkは不要であれば最終的に削除して良いかと思います。）
![image](https://user-images.githubusercontent.com/56940903/100028977-8389fb80-2e33-11eb-9631-c6880f473af9.png)

## やらないこと
* update_user_idは次のプルリクで改善します。
## できるようになること(ユーザ目線)
* どのページからも案件の新規作成ができます。
## できなくなること(ユーザ目線)
* ステータスがテンプレートであるにも関わらず、テンプレートにチェックが入っていなかったり、進捗が進捗中になっていたりすること
## 動作確認
* 案件の編集（成功／失敗）、案件の削除を行い、正常に挙動することを確認しました。
## その他
* 特になし
