### PR TITLE
start_stepの一部修正とtasks/show.html.erbの日本語化

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -25,3 +25,18 @@
 input[type="date"] {
   width: 200px;
 }
+
+.task-show-table {
+  display: block;
+  width: 400px;
+  margin-left: 100px;
+}
+
+.task-show-table th {
+  width: 30%;
+}
+
+.task-show-table td {
+  width: 50%;
+}
+

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -16,7 +16,7 @@ class Leads::ApplicationController < Users::ApplicationController
   def start_step(lead, step)
     ActiveRecord::Base.transaction do
       # 進捗開始処理
-      scheduled_complete_date = params[:step].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
+      scheduled_complete_date = params[:step][:scheduled_complete_date].present? ? params[:step][:scheduled_complete_date] : "#{Date.current}"
       if step.status?("in_progress")
         flash[:success] = "#{step.name}は既に進捗中です。"
       else

--- a/app/views/leads/tasks/show.html.erb
+++ b/app/views/leads/tasks/show.html.erb
@@ -1,40 +1,38 @@
-<p>
-  <strong>Step_id:</strong>
-  <%= @task.step_id %>
-</p>
-
-<p>
-  <strong>Name:</strong>
-  <%= @task.name %>
-</p>
-
-<p>
-  <strong>Memo:</strong>
-  <%= @task.memo %>
-</p>
-
-<p>
-  <strong>Status:</strong>
-  <%= @task.status %>
-</p>
-
-<p>
-  <strong>Scheduled_complete_date:</strong>
-  <%= @task.scheduled_complete_date %>
-</p>
-
-<p>
-  <strong>Completed_date:</strong>
-  <%= @task.completed_date %>
-</p>
-
-<p>
-  <strong>Canceled_date</strong>
-  <%= @task.canceled_date %>
-</p>
-
-
+<h1>タスク詳細</h1>
+<div>
+  <table class="table table-condensed task-show-table">
+    <tr>
+      <th>進捗ID</th>
+      <td><%= @task.step_id %></td>
+    </tr>
+    <tr>
+      <th>タスク名</th>
+      <td><%= @task.name %></td>
+    </tr>
+    <tr>
+      <th>タスク詳細</th>
+      <td><%= @task.memo %></td>
+    </tr>
+    <tr>
+      <th>タスクステータス</th>
+      <td><%= I18n.t("enums.task.status.#{@task.status}") %></td>
+    </tr>
+    <tr>
+      <th>完了予定日</th>
+      <td><%= @task.scheduled_complete_date %></td>
+    </tr>
+    <tr>
+      <th>完了日</th>
+      <td><%= @task.completed_date %></td>
+    </tr>
+    <tr>
+      <th>中止にした日</th>
+      <td><%= @task.canceled_date %></td>
+    </tr>
+  </table>
+</div>
 <%= link_to '編集', edit_task_path(@task) %>
 <%= link_to '削除', task_path(@task), method: :delete, data: { confirm: "「#{@task.name}」を削除してよろしいですか？" } %>
 <!-- steps#showに戻る -->
 <%= link_to '戻る', step_path(@step) %>
+


### PR DESCRIPTION
## やったこと
app/controllers/leads/application_controllerのstart_stepメソッドの一部修正とapp/views/leads/tasks/show.html.erbの日本語化
## やらないこと
無し。
## できるようになること(ユーザ目線)
「完了済進捗編集時イベント」の②現在の進捗を「進捗中」にするを選び「完了予定日」を空白にした時、進捗が「完了」のままでなく、現在の日付を「完了予定日」とし、進捗が正しく「進捗中」になる。
タスク詳細ページで日本語表記で参照できる。
## できなくなること(ユーザ目線)
無し。
## 動作確認
「完了済進捗編集時イベント」の②現在の進捗を「進捗中」にするを選び、完了予定日を空白した時の動作確認。タスク詳細ページの閲覧。
## その他
Taskのテスト項目書に記述したテストをしているときに発見したバグの修正とタスク詳細ページを日本語化しました。
