### PR TITLE
view期限変更通知作成

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -2,7 +2,7 @@ class Leads::StepsController < Leads::ApplicationController
   # オブジェクトの準備
   before_action :set_step, except: %i(index new create)
   before_action :set_lead_and_user_by_lead_id, only: %i(index new create)
-  before_action :set_steps, only: %i(show)
+  before_action :set_steps, :set_users, only: %i(show)
   # フィルター（アクセス権限）
   before_action :only_same_company_id?
   before_action :correct_user, except: %i(index show change_limit_check)

--- a/app/views/leads/steps/_steps_notice.html.erb
+++ b/app/views/leads/steps/_steps_notice.html.erb
@@ -1,8 +1,16 @@
 <% if @steps_notice_list.present? %>
-  <% @steps_notice_list.each do |step| %>
-    <p>
-      <%= step.name %>
-      <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"} %>
-    </p>
-  <% end %>
+  <div class="alert alert-info" role="alert">
+    <h4 class="alert-heading">期限変更</h4>
+    <p>確認者: <%= @users.find(@user.superior_id).name %></p>
+    <hr>
+    <% @steps_notice_list.each_with_index do |step, index| %>
+      <div class="mb-0">
+        <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary" %>
+        : <%= link_to "#{step.name}", step_path(step) %>
+      </div>
+      <% unless @steps_notice_list.last(index) %>
+        <br>
+      <% end %>
+    <% end %>
+  </div>
 <% end %>


### PR DESCRIPTION

issue #109 
### やったこと
step_pathの期限変更通知にデザインを充てました
## やらないこと
特になし
## できるようになること(ユーザ目線)
期限変更通知がわかりやすくなりました
## できなくなること(ユーザ目線)
特になし
## 動作確認
サーバーを起動し手動確認をしました。
## その他
参考画像
<img width="1072" alt="スクリーンショット 2020-12-01 12 26 39" src="https://user-images.githubusercontent.com/53179825/100696403-c705dc00-33d6-11eb-8901-e41b1ac2786c.png">
確認、レビューお願いします。