### PR TITLE
Bug fix when changing value with developer tool

### DIFF
--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -31,7 +31,6 @@ class Leads::ApplicationController < Users::ApplicationController
       # 新規タスク作成
       if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
         @task = step.tasks.create(task_simple_params)
-        @task.update_attributes(step_id: @step.id)
         flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
       end
       # 案件を再開する場合の処理

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -292,6 +292,6 @@ class Leads::ApplicationController < Users::ApplicationController
     end
 
     def task_simple_params
-      params.require(:task).permit(:name, :status, :scheduled_complete_date)
+      params.require(:task).permit(:step_id, :name, :status, :scheduled_complete_date)
     end
 end

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -31,6 +31,7 @@ class Leads::ApplicationController < Users::ApplicationController
       # 新規タスク作成
       if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
         @task = step.tasks.create(task_simple_params)
+        @task.update_attributes(step_id: @step.id)
         flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
       end
       # 案件を再開する場合の処理
@@ -291,6 +292,6 @@ class Leads::ApplicationController < Users::ApplicationController
     end
 
     def task_simple_params
-      params.require(:task).permit(:step_id, :name, :status, :scheduled_complete_date)
+      params.require(:task).permit(:name, :status, :scheduled_complete_date)
     end
 end

--- a/app/controllers/leads/application_controller.rb
+++ b/app/controllers/leads/application_controller.rb
@@ -291,6 +291,6 @@ class Leads::ApplicationController < Users::ApplicationController
     end
 
     def task_simple_params
-      params.require(:task).permit(:step_id, :name, :status, :scheduled_complete_date)
+      params.require(:task).permit(:name, :status, :scheduled_complete_date)
     end
 end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -70,7 +70,7 @@ class Leads::StepsController < Leads::ApplicationController
   # PATCH/PUT /steps/1
   # PATCH/PUT /steps/1.json
   def update
-    @tasks_not_yet_present = @step.tasks.not_yet.present? ? true : false
+    @present_not_yet_tasks = @step.tasks.not_yet.present? ? true : false
     # タスク新規作成
     @task = @step.tasks.new(task_params)
     if update_step_errors(@lead, @step).blank?
@@ -182,7 +182,7 @@ class Leads::StepsController < Leads::ApplicationController
         flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。" if prohibit_past(step.completed_date)
         lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
         #stepにタスクがすでにある場合作る必要が無く、stepが「未」または「完了」のときタスクがあればバリデーションに反するので削除する
-        if @tasks_not_yet_present || step.status?("not_yet") || step.status?("completed")
+        if @present_not_yet_tasks || step.status?("not_yet") || step.status?("completed")
           @task.destroy
         else
           flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -165,7 +165,7 @@ class Leads::StepsController < Leads::ApplicationController
         # バリデーション確認
         errors << lead.errors.full_messages if lead.invalid?(:check_steps_status)
         errors << step.errors.full_messages if step.invalid?(:check_order)
-        errors << @task.errors.full_messages if @task.invalid?
+        errors << @task.errors.full_messages if @task.present? && @task.invalid?
         raise ActiveRecord::Rollback if errors.present?
       end
       errors.presence || nil
@@ -181,7 +181,7 @@ class Leads::StepsController < Leads::ApplicationController
         flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。" if prohibit_past(step.scheduled_complete_date)
         flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。" if prohibit_past(step.completed_date)
         lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
-        #stepにタスクがすでにある場合またはstepが「未」または「完了」のときはtaskを作らない
+        #stepにタスクがすでにある場合作る必要が無く、stepが「未」または「完了」のときタスクがあればバリデーションに反するので削除する
         if @tasks_not_yet_present || step.status?("not_yet") || step.status?("completed")
           @task.destroy
         else
@@ -194,7 +194,7 @@ class Leads::StepsController < Leads::ApplicationController
         # バリデーション確認
         errors << lead.errors.full_messages if lead.invalid?(:check_steps_status)
         errors << step.errors.full_messages if step.invalid?(:check_order)
-        errors << @task.errors.full_messages if @task.invalid?
+        errors << @task.errors.full_messages if @task.present? && @task.invalid?
         raise ActiveRecord::Rollback if errors.present?
       end
       errors.presence || nil

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -71,6 +71,7 @@ class Leads::StepsController < Leads::ApplicationController
   # PATCH/PUT /steps/1.json
   def update
     @task = Task.new(task_params)
+    @task.update_attributes(step_id: @step.id)
     if update_step_errors(@lead, @step).blank?
       flash[:success] = "#{flash[:success]}#{@step.name}を更新しました。"
       check_status_and_redirect_to(@step, @step, nil)
@@ -131,7 +132,7 @@ class Leads::StepsController < Leads::ApplicationController
     end
 
     def task_params
-      params.require(:task).permit(:step_id, :name, :memo, :status, :scheduled_complete_date, :completed_date, :canceled_date)
+      params.require(:task).permit(:name, :memo, :status, :scheduled_complete_date, :completed_date, :canceled_date)
     end
     
     # クリエイト処理
@@ -182,6 +183,7 @@ class Leads::StepsController < Leads::ApplicationController
         # 新規タスク作成
         if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
           @task =Task.create(task_params)
+          @task.update_attributes(step_id: @step.id)
           flash[:danger] = "#{flash[:danger]}タスクの完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
           flash[:danger] = "#{flash[:danger]}タスクの完了日に過去の日付を入力しようとしています。" if prohibit_past(@task.completed_date)
         end

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -33,6 +33,7 @@ class Leads::TasksController < Leads::ApplicationController
 
   def create
     @task = Task.new(task_params)
+    @task.update_attributes(step_id: @step.id)
     flash[:danger] = "完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
     if @task.save
       update_completed_tasks_rate(@step)
@@ -44,7 +45,8 @@ class Leads::TasksController < Leads::ApplicationController
 
 
   def update
-    if @task.update(task_params) 
+    if @task.update(task_params)
+      @task.update_attributes(step_id: @step.id)
       update_completed_tasks_rate(@step)
       # 完了日が空なら今日の日付を入れる
       @task.date_blank_then_today("completed")
@@ -173,7 +175,7 @@ class Leads::TasksController < Leads::ApplicationController
     end
 
     def task_params
-      params.require(:task).permit(:step_id, :name, :memo, :status, :scheduled_complete_date, :completed_date, :canceled_date)
+      params.require(:task).permit(:name, :memo, :status, :scheduled_complete_date, :completed_date, :canceled_date)
     end
 
     def revive_from_canceled_list_params

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -32,8 +32,7 @@ class Leads::TasksController < Leads::ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
-    @task.update_attributes(step_id: @step.id)
+    @task = @step.tasks.new(task_params)
     flash[:danger] = "完了予定日に過去の日付を入力しようとしています。" if prohibit_past(@task.scheduled_complete_date)
     if @task.save
       update_completed_tasks_rate(@step)

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -46,7 +46,6 @@ class Leads::TasksController < Leads::ApplicationController
 
   def update
     if @task.update(task_params)
-      @task.update_attributes(step_id: @step.id)
       update_completed_tasks_rate(@step)
       # 完了日が空なら今日の日付を入れる
       @task.date_blank_then_today("completed")

--- a/app/views/leads/step_statuses/_start.html.erb
+++ b/app/views/leads/step_statuses/_start.html.erb
@@ -9,8 +9,6 @@
     <%= fields_for task do |t| %>
       <%= render 'devise/shared/error_messages', resource: task %>
 
-      <%= t.hidden_field :step_id, value: step.id %>
-
       <div class="field">
         <%= t.label :name %>
         <%= t.text_field :name %>

--- a/app/views/leads/step_statuses/_start.html.erb
+++ b/app/views/leads/step_statuses/_start.html.erb
@@ -9,6 +9,8 @@
     <%= fields_for task do |t| %>
       <%= render 'devise/shared/error_messages', resource: task %>
 
+      <%= t.hidden_field :step_id, value: step.id %>
+
       <div class="field">
         <%= t.label :name %>
         <%= t.text_field :name %>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -63,8 +63,6 @@
   <%= fields_for @task do |t| %>
     <%= render 'devise/shared/error_messages', resource: @task %>
 
-    <%= t.hidden_field :step_id, value: step.id %>
-
     <div class="field">
       <%= t.label :name %>
       <%= t.text_field :name %><br>

--- a/app/views/leads/tasks/edit.html.erb
+++ b/app/views/leads/tasks/edit.html.erb
@@ -43,7 +43,6 @@
   <div>
     <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
   </div>
-  <%= f.hidden_field :step_id, class: "form-control", value: @step.id %>
 
 <% end %>
 <!-- steps#showに戻る -->

--- a/app/views/leads/tasks/new.html.erb
+++ b/app/views/leads/tasks/new.html.erb
@@ -14,8 +14,6 @@
 
   <%= f.submit yield(:button_text), class: "btn-#{yield(:class_text)}" %>
 
-  <%= f.hidden_field :step_id, class: "form-control", value: @step.id %>
-
 <% end %>
 
 <!-- steps#showに戻る -->


### PR DESCRIPTION
## やったこと
デベロッパーツールでフォームのvalue値を変更することにより、他のユーザーのタスクが生成できてしまうバグの修正。
具体的には、ストロングパラメータから(hidden_field経由の):step_idを消去して、`@task = Task.new(task_params)`の後に
`@task.update_attributes(step_id: @step.id)`としました。
## やらないこと
無し。
## できるようになること(ユーザ目線)
無し。
## できなくなること(ユーザ目線)
デベロッパーツールのフォームのvalue値を変更することにより、他のユーザーのタスクを生成すること。
## 動作確認
タスク新規作成、タスク更新、進捗の新規作成時の同時タスク生成、進捗の直接更新時のタスク生成、start_stepメソッド中のタスク生成が問題なくできることを確認しました。
## その他
特にありません。
