### PR TITLE
進捗の期限変更通知をtrueにするロジック追加

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -178,7 +178,10 @@ class Leads::StepsController < Leads::ApplicationController
         step.update(step_params)
         flash[:danger] = "#{flash[:danger]}進捗の完了予定日に過去の日付を入力しようとしています。" if prohibit_past(step.scheduled_complete_date)
         flash[:danger] = "#{flash[:danger]}進捗の完了日に過去の日付を入力しようとしています。" if prohibit_past(step.completed_date)
-        lead.update_attribute(:notice_change_limit, true) if step.saved_change_to_scheduled_complete_date?
+        if step.saved_change_to_scheduled_complete_date?
+          step.update_attribute(:notice_change_limit, true)
+          lead.update_attribute(:notice_change_limit, true)
+        end
         # 新規タスク作成
         if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank?
           @task =Task.create(task_params)

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -106,7 +106,7 @@ class Leads::StepsController < Leads::ApplicationController
       @lead.update(notice_change_limit: false) if @lead.steps.where(notice_change_limit: true).blank?
       flash[:success] = "確認しました。"
     else
-      flash[:danger] = "確認処理に失敗しました。"
+      flash[:danger] = "指定されたユーザーしか確認できません。"
     end
     redirect_to @step
   end

--- a/app/views/leads/steps/_steps_notice.html.erb
+++ b/app/views/leads/steps/_steps_notice.html.erb
@@ -2,15 +2,12 @@
   <div class="alert alert-info" role="alert">
     <h4 class="alert-heading">期限変更</h4>
     <p>確認者: <%= @users.find(@user.superior_id).name %></p>
-    <hr>
     <% @steps_notice_list.each do |step| %>
+      <hr>
       <div class="mb-0">
         <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary" %>
         : <%= link_to "#{step.name}", step_path(step) %>
       </div>
-      <% unless @steps_notice_list.last == step %>
-        <hr>
-      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/leads/steps/_steps_notice.html.erb
+++ b/app/views/leads/steps/_steps_notice.html.erb
@@ -3,13 +3,13 @@
     <h4 class="alert-heading">期限変更</h4>
     <p>確認者: <%= @users.find(@user.superior_id).name %></p>
     <hr>
-    <% @steps_notice_list.each_with_index do |step, index| %>
+    <% @steps_notice_list.each do |step| %>
       <div class="mb-0">
         <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary" %>
         : <%= link_to "#{step.name}", step_path(step) %>
       </div>
-      <% unless @steps_notice_list.last(index) %>
-        <br>
+      <% unless @steps_notice_list.last == step %>
+        <hr>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
## やったこと
進捗の期限変更通知をtrueにupdateするロジックを追加
通知のviewを若干修正
## やらないこと
なし
## できるようになること(ユーザ目線)
一つの案件に対して複数の進捗の期限変更通知を正しく取得できる。
## できなくなること(ユーザ目線)
特になし
## 動作確認
手動テスト
## その他
特にありません。
viewの修正は各確認ボタンが密接していたのでhrタグで線とスペースをあけました。
コードレビューよろしくお願いします。
参考
<img width="1188" alt="スクリーンショット 2020-12-03 11 39 46" src="https://user-images.githubusercontent.com/53179825/100956674-4ec92300-355c-11eb-94d4-eaff99bf909f.png">

