### PR TITLE
statuses_make_step_not_yetアクションの移設及び名称変更

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -84,18 +84,6 @@ class Leads::StepsController < Leads::ApplicationController
     destroy_step(@lead, @step)
   end
 
-  # 進捗を未にする
-  def statuses_make_step_not_yet
-    errors = []
-    ActiveRecord::Base.transaction do
-      errors << @step.errors.full_messages unless @step.update_attributes(status: "not_yet")
-      update_steps_rate(@lead)
-      errors << @lead.errors.full_messages if @lead.invalid?(:check_steps_status)
-      raise ActiveRecord::Rollback if errors.present?
-    end
-    redirect_to check_status_and_get_url(@step, @step)
-  end
-
   # Stepの期限変更通知をfalseに更新
   def change_limit_check
     if @user.superior_id == current_user.id

--- a/app/controllers/leads/steps_statuses_controller.rb
+++ b/app/controllers/leads/steps_statuses_controller.rb
@@ -31,4 +31,17 @@ class Leads::StepsStatusesController < Leads::StepsController
   def cancel
     cancel_step(@lead, @step)
   end
+  
+  # 進捗を未にする
+  def back_to_not_yet
+    errors = []
+    ActiveRecord::Base.transaction do
+      errors << @step.errors.full_messages unless @step.update_attributes(status: "not_yet")
+      update_steps_rate(@lead)
+      errors << @lead.errors.full_messages if @lead.invalid?(:check_steps_status)
+      raise ActiveRecord::Rollback if errors.present?
+    end
+    redirect_to check_status_and_get_url(@step, @step)
+  end
+
 end

--- a/app/views/leads/steps/edit_change_status_or_complete_task.html.erb
+++ b/app/views/leads/steps/edit_change_status_or_complete_task.html.erb
@@ -1,6 +1,6 @@
 <h3><%= step_name(@step) %>のステータスは「完了」ですが、「未」のタスクがあります</h3>
 <h4>&#9312;現在の進捗を「未」にする</h4>
-<%= button_to '更新', statuses_make_step_not_yet_step_path(@step), method: :patch %>
+<%= button_to '更新', back_to_not_yet_step_path(@step), method: :patch %>
 <br>
 <h4>&#9313;現在の進捗を「進捗中」にする</h4>
 <%= render 'leads/step_statuses/start', step: @step, completed_id: nil, new_task: nil, task: @task, loop_ok: true, button_name: "開始" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,8 @@ Rails.application.routes.draw do
         patch 'complete/:completed_id' => 'steps_statuses#complete', as: :complete
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
-        patch 'statuses_make_step_not_yet'
+#        patch 'statuses_make_step_not_yet'
+        patch 'back_to_not_yet' => 'steps_statuses#back_to_not_yet', as: :statuses_make_step_not_yet
         patch 'change_limit_check'
         get 'edit_continue_or_destroy_step'
         get 'edit_complete_or_continue_step'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
         patch 'start' => 'steps_statuses#start', as: :start
         patch 'cancel' => 'steps_statuses#cancel', as: :cancel
 #        patch 'statuses_make_step_not_yet'
-        patch 'back_to_not_yet' => 'steps_statuses#back_to_not_yet', as: :statuses_make_step_not_yet
+        patch 'back_to_not_yet' => 'steps_statuses#back_to_not_yet', as: :back_to_not_yet
         patch 'change_limit_check'
         get 'edit_continue_or_destroy_step'
         get 'edit_complete_or_continue_step'


### PR DESCRIPTION
## やったこと
* statuses_make_step_not_yetアクションはstepのstatusを変更する処理しているため、stepコントローラというよりは、step_statusコントローラが適切と考え、移管した。
* 移管に伴い、stepのstatusに対するアクションであることは明確になったので、「未」の状態に戻すことが直感的にわかるよう、アクション名をback_to_not_yetに変更した。
## やらないこと
* なし
## できるようになること(ユーザ目線)
* なし
## できなくなること(ユーザ目線)
* なし
## 動作確認
* /steps/:id/edit_change_status_or_complete_taskのページから、問題なく進捗を「未」にできることを確認した。
![image](https://user-images.githubusercontent.com/56940903/101995575-3f8d6680-3d0e-11eb-93ed-7fa5a6119274.png)

## その他
* なし
