### PR TITLE
通知確認ボタン通知受信者以外クリック不可

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -8,4 +8,9 @@ module UsersHelper
   def delete_judgment(user)
     user.admin? || user.company_id != current_user.company_id ? false : true
   end
+
+  # 引数のユーザーがcurrent_userと同じか判定
+  def correct_user?(user)
+    user == current_user ? true : false
+  end
 end

--- a/app/views/leads/steps/show.html.erb
+++ b/app/views/leads/steps/show.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<%= render 'leads/steps/show/notice' %>
+<%= render 'leads/steps/show/notice' if @steps_notice_list.present? %>
 
 <h1>案件詳細</h1>
 <%= render partial: 'leads/leads/lead_show' %>

--- a/app/views/leads/steps/show/_notice.html.erb
+++ b/app/views/leads/steps/show/_notice.html.erb
@@ -1,11 +1,12 @@
 <% if @steps_notice_list.present? %>
   <div class="alert alert-info" role="alert">
     <h4 class="alert-heading">期限変更</h4>
-    <p>確認者: <%= @users.find(@user.superior_id).name %></p>
+    <% superior = @users.find(@user.superior_id) %>
+    <p>確認者: <%= superior.name %></p>
     <% @steps_notice_list.each do |step| %>
       <hr>
       <div class="mb-0">
-        <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary" %>
+        <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary #{"disabled" unless correct_user?(superior) }" %>
         : <%= link_to "#{step.name}", step_path(step) %>
       </div>
     <% end %>

--- a/app/views/leads/steps/show/_notice.html.erb
+++ b/app/views/leads/steps/show/_notice.html.erb
@@ -1,14 +1,13 @@
-<% if @steps_notice_list.present? %>
-  <div class="alert alert-info" role="alert">
-    <h4 class="alert-heading">期限変更</h4>
-    <% superior = @users.find(@user.superior_id) %>
-    <p>確認者: <%= superior.name %></p>
-    <% @steps_notice_list.each do |step| %>
-      <hr>
-      <div class="mb-0">
-        <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary #{"disabled" unless correct_user?(superior) }" %>
-        : <%= link_to "#{step.name}", step_path(step) %>
-      </div>
-    <% end %>
-  </div>
-<% end %>
+<% superior = @users.find(@user.superior_id) %>
+
+<div class="alert alert-info" role="alert">
+  <h4 class="alert-heading">期限変更</h4>
+  <p>確認者: <%= superior.name %></p>
+  <% @steps_notice_list.each do |step| %>
+    <hr>
+    <div class="mb-0">
+      <%= link_to "確認", change_limit_check_step_path(step), method: :patch, data: { confirm: "期限の変更を確認します。"}, class: "btn btn-sm btn-primary #{"disabled" unless correct_user?(superior) }" %>
+      : <%= link_to "#{step.name}", step_path(step) %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
## やったこと
issue #119 の修正
## やらないこと
特になし
## できるようになること(ユーザ目線)
通知受信者以外のユーザーは表示自体はされるがクリックしても反応しないようdisabledを付与しました。
## 動作確認
実際にページを見て、クラスが付与されていること、正しい受信者は正常に確認できることを確認しました。
## その他
コードレビューよろしくお願いします。

一緒に今回の変更と同時にissueの自動closeをできるかチェックします。
close #119 
