### PR TITLE
issue #128に対する修正と各イベント操作後のページのbefore actionの変更

### DIFF
--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -260,11 +260,11 @@ class Leads::StepsController < Leads::ApplicationController
     end
 
     def contradiction_detection(step)
-      if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank? && step.tasks.completed.blank?
+      if (step.status?("in_progress") || step.status?("inactive")) && continue_or_destroy_step?(step)
         redirect_to edit_continue_or_destroy_step_step_url(step)
-      elsif (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank? && step.tasks.completed.present?
+      elsif (step.status?("in_progress") || step.status?("inactive")) && complete_or_continue_step?(step)
         redirect_to edit_complete_or_continue_step_step_url(step)
-      elsif step.status?("completed") && step.tasks.not_yet.present?
+      elsif change_status_or_complete_task?(step)
         redirect_to edit_change_status_or_complete_task_step_url(step)
       end
     end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -274,7 +274,7 @@ class Leads::StepsController < Leads::ApplicationController
 
     # 完了済進捗編集時イベントページを要求したとき、「stepに「未」のタスクがあるにも関わらず、@stepのstatusが「完了」」でなく、かつ$through_check_status変数がfalseなら、強制リダイクト
     def correct_change_status_or_complete_task_status(step)
-      if !change_status_or_complete_task?(step) && !$through_check_status
+      if !change_status_or_complete_task?(step)
         flash[:danger] = "完了済進捗編集時イベントの条件に合いません"
         redirect_to step
       end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -12,6 +12,9 @@ class Leads::StepsController < Leads::ApplicationController
   before_action ->{
     correct_status(@step)
   }, only: %i(edit_continue_or_destroy_step edit_complete_or_continue_step edit_change_status_or_complete_task)
+  before_action ->{
+    contradiction_detection(@step)
+  }, only: :show
 
 
   # GET /steps
@@ -256,4 +259,14 @@ class Leads::StepsController < Leads::ApplicationController
       end
     end
 
+    def contradiction_detection(step)
+      if (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank? && step.tasks.completed.blank?
+        redirect_to edit_continue_or_destroy_step_step_url(step)
+      elsif (step.status?("in_progress") || step.status?("inactive")) && step.tasks.not_yet.blank? && step.tasks.completed.present?
+        redirect_to edit_complete_or_continue_step_step_url(step)
+      elsif step.status?("completed") && step.tasks.not_yet.present?
+        redirect_to edit_change_status_or_complete_task_step_url(step)
+      end
+    end
+ 
 end

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -246,7 +246,7 @@ class Leads::StepsController < Leads::ApplicationController
 
     # 進捗新規作成時イベントページを要求したとき、「stepに「未」のタスクも「完了」のタスクも無い」でなければ、強制リダイレクト
     def correct_continue_or_destroy_step_status(step)
-      if !continue_or_destroy_step?(step)
+      unless continue_or_destroy_step?(step)
         flash[:danger] = "進捗新規作成時イベントの条件に合いません"
         redirect_to step
       end
@@ -254,21 +254,21 @@ class Leads::StepsController < Leads::ApplicationController
 
     # 進捗完了時イベントページを要求したとき、「「未」のタスクが無く「完了」のタスクが1つ以上ある」でなければ、強制リダイレクト
     def correct_complete_or_continue_step_status(step)
-      if !complete_or_continue_step?(step)
+      unless complete_or_continue_step?(step)
         flash[:danger] = "進捗完了時イベントの条件に合いません"
         redirect_to step
       end
     end
 
-    # 完了済進捗編集時イベントページを要求したとき、「stepに「未」のタスクがあるにも関わらず、@stepのstatusが「完了」」でなく、かつ$through_check_status変数がfalseなら、強制リダイクト
+    # 完了済進捗編集時イベントページを要求したとき、「stepに「未」のタスクがあるにも関わらず、@stepのstatusが「完了」」でなければ、強制リダイクト
     def correct_change_status_or_complete_task_status(step)
-      if !change_status_or_complete_task?(step)
+      unless change_status_or_complete_task?(step)
         flash[:danger] = "完了済進捗編集時イベントの条件に合いません"
         redirect_to step
       end
     end
 
-
+    # leads/steps#show画面を表示する前にタスク-進捗が矛盾した状態にあれば各タスク操作後のイベントページにリダイレクトする
     def contradiction_detection(step)
       if (step.status?("in_progress") || step.status?("inactive")) && continue_or_destroy_step?(step)
         redirect_to edit_continue_or_destroy_step_step_url(step)

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -64,7 +64,7 @@
     ↓進捗ステータスで「進捗中」、または「保留」を選んだ場合、「タスク名」、「完了予定日」は入力必須<br>
     ↓それ以外は、空欄可<br><br>
     <%= fields_for @task do |t| %>
-      <%= render 'devise/shared/error_messages', resource: @task if @task.present? %>
+      <%= render 'devise/shared/error_messages', resource: @task %>
 
       <div class="field">
         <%= t.label :name %>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -64,7 +64,7 @@
     ↓進捗ステータスで「進捗中」、または「保留」を選んだ場合、「タスク名」、「完了予定日」は入力必須<br>
     ↓それ以外は、空欄可<br><br>
     <%= fields_for @task do |t| %>
-      <%= render 'devise/shared/error_messages', resource: @task %>
+      <%= render 'devise/shared/error_messages', resource: @task if @task.present? %>
 
       <div class="field">
         <%= t.label :name %>


### PR DESCRIPTION
## やったこと
①issue   #128に対する修正
具体的には、タスクの矛盾を解消するページから@stepへ戻った時、矛盾する状態だったら再び矛盾を解消するページにredirectするようにしました。
②3条件まとめて判別していたcheck_statusメソッドを、1つ1つ分けなければならない状況に対応するため、3条件を分けたcorrect_continue_or_destroy_step_status、correct_complete_or_continue_step_status、correct_change_status_or_complete_task_statusメソッドをそれぞれbefore actionで実行するようにしました。
## やらないこと
issue#130に対する修正はまだやっていません。
## できるようになること(ユーザ目線)
①戻るボタンで戻った時でも矛盾の無い状態にするページにリダイレクトされる。
②3つ条件の内１つの条件に合致しているとき、その他の条件のページへリダイレクトを要求しても@stepへ強制リダイレクトされる。
## できなくなること(ユーザ目線)
タスク―ステップの矛盾した状態にすること。
## 動作確認
①タスク操作後のイベントページから戻るボタンを押し、@stepにページ遷移後、再読み込みボタンを押したとき、タスク操作後のイベントページにリダイレクトされること。進捗完了時イベントページ、完了済進捗編集時イベントページから戻るボタンを押し、@stepぺージに遷移後、完了済の進捗を現在の進捗にしたとき、タスク操作後のイベントページにリダイレクトされること。
②3条件のうち一つに合致しているとき、その他の条件のページへリダイレクトを要求したら@stepへリダイレクトされること。
## その他
3条件まとめて判別していたcheck_statusメソッドを3条件を分けた理由につきましては、下で説明させていただきます。
close #128 