### PR TITLE
issue#130に対する修正とjavascriptによる新規タスク作成フォームの制御

### DIFF
--- a/app/assets/javascripts/control_new_task.js
+++ b/app/assets/javascripts/control_new_task.js
@@ -1,0 +1,6 @@
+$(function(){
+  $('#selector select[name="step[status]"]').on('change', function() {
+    if ($('select[name="step[status]"]').val()=='in_progress' || $('select[name="step[status]"]').val()=='inactive') $('#new_task').css('display','block');
+    else $('#new_task').css('display','none');
+  });
+});

--- a/app/assets/javascripts/control_new_task.js
+++ b/app/assets/javascripts/control_new_task.js
@@ -1,4 +1,4 @@
-// 進捗ステータスで「進捗中」または「保留」を選んだ時以外、新規タスク作成フォームは表示しない
+// 新規進捗作成の進捗ステータスで「進捗中」または「保留」を選んだ時以外、新規タスク作成フォームは表示しない
 $(function(){
   $('#selector select[name="step[status]"]').on('change', function() {
     if ($('select[name="step[status]"]').val()=='in_progress' || $('select[name="step[status]"]').val()=='inactive') $('#new_task').css('display','block');

--- a/app/assets/javascripts/control_new_task.js
+++ b/app/assets/javascripts/control_new_task.js
@@ -1,3 +1,4 @@
+// 進捗ステータスで「進捗中」または「保留」を選んだ時以外、新規タスク作成フォームは表示しない
 $(function(){
   $('#selector select[name="step[status]"]').on('change', function() {
     if ($('select[name="step[status]"]').val()=='in_progress' || $('select[name="step[status]"]').val()=='inactive') $('#new_task').css('display','block');

--- a/app/controllers/leads/steps_controller.rb
+++ b/app/controllers/leads/steps_controller.rb
@@ -171,8 +171,7 @@ class Leads::StepsController < Leads::ApplicationController
         end
         if step.status?("completed")
           flash[:danger] = "「完了」タスクが無い、進捗は「完了」ステータスで新規作成しようとしています。「完了」タスクを自動で生成しました。"
-          scheduled_complete_date = present_value([params[:step][:scheduled_complete_date], "#{Date.current}"])
-          @task = step.tasks.new(name: "completed_task", status: "completed", scheduled_complete_date: scheduled_complete_date, completed_date: params[:step][:completed_date])
+          @task = step.tasks.new(name: "completed_task", status: "completed", scheduled_complete_date: "#{Date.current}", completed_date: "#{Date.current}")
           update_completed_tasks_rate(step)
         end
 

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -4,6 +4,7 @@ class Leads::TasksController < Leads::ApplicationController
                                     edit_revive_from_canceled_list update_revive_from_canceled_list)
   before_action :set_step, only: %i(index new create)
   before_action :set_step_by_id, only: [:add_delete_list, :complete_all_tasks]
+  before_action :set_steps, only: :create
   # アクセス制限
   before_action :correct_user, except: %i(index show)
 
@@ -35,7 +36,9 @@ class Leads::TasksController < Leads::ApplicationController
       check_status_and_redirect_to(@step, @step, nil)
     else
       flash[:danger] = "#{@task.errors.full_messages.first}"
-      redirect_to @step
+      render :template=> "leads/steps/show", :collection => @steps, :locals=> { :@tasks=> @step.tasks.not_yet.order(:scheduled_complete_date), 
+                                                                                :@completed_tasks => @step.tasks.completed.order(:completed_date),
+                                                                                :@canceled_tasks => @step.tasks.canceled.order(:canceled_date) }
     end
   end
 

--- a/app/controllers/leads/tasks_controller.rb
+++ b/app/controllers/leads/tasks_controller.rb
@@ -34,7 +34,8 @@ class Leads::TasksController < Leads::ApplicationController
       update_completed_tasks_rate(@step)
       check_status_and_redirect_to(@step, @step, nil)
     else
-      render :new 
+      flash[:danger] = "#{@task.errors.full_messages.first}"
+      redirect_to @step
     end
   end
 

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -49,7 +49,7 @@ $(function(){
 
     <div class="field" id="selector">
       <%= form.label :status %>
-      <%= form.select :status, Step.statuses.keys.map { |k| [I18n.t("enums.step.status.#{k}"), k]} %>
+      <%= form.select :status, Step.statuses.keys.map { |k| [I18n.t("enums.step.status.#{k}"), k]}, {selected: "in_progress"}%>
     </div>
   
     <div class="field">

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -1,3 +1,11 @@
+<script type="text/javascript">
+$(function(){
+  $('#selector select[name="step[status]"]').on('change', function() {
+    if ($('select[name="step[status]"]').val()=='in_progress' || $('select[name="step[status]"]').val()=='inactive') $('#new_task').css('display','block');
+    else $('#new_task').css('display','none');
+  });
+});
+</script>
 <%= form_with(model: [lead, step], local: true) do |form| %>
   <%= render 'devise/shared/error_messages', resource: @step %>
 
@@ -39,7 +47,7 @@
     
   <% elsif step.new_record? || step.status?("in_progress") %>
 
-    <div class="field">
+    <div class="field" id="selector">
       <%= form.label :status %>
       <%= form.select :status, Step.statuses.keys.map { |k| [I18n.t("enums.step.status.#{k}"), k]} %>
     </div>
@@ -75,48 +83,49 @@
     </div>
     
   <% end %>
-  
-  
-  <% if @step.tasks.not_yet.blank? && (step.new_record? || step.status?("in_progress")) %>
+ 
+  <div id="new_task"> 
+    <% if step.tasks.not_yet.blank? && step.new_record? %>
 
-    <hr>
+      <hr>
 
-    ↓進捗ステータスで「進捗中」、または「保留」を選んだ場合、「タスク名」、「完了予定日」は入力必須<br>
-    ↓それ以外は、空欄可<br><br>
-    <%= fields_for @task do |t| %>
-      <%= render 'devise/shared/error_messages', resource: @task if @task.present? %>
+      ↓「タスク名」、「完了予定日」は入力必須<br>
+      ↓それ以外は、空欄可<br><br>
+      <%= fields_for @task do |t| %>
+        <%= render 'devise/shared/error_messages', resource: @task if @task.present? %>
 
-      <div class="field">
-        <%= t.label :name %>
-        <%= t.text_field :name %><br>
-        ↑ 入力必須<br>
-      </div>
-      <div class="field">
-        <%= t.label :memo %>
-        <%= t.text_area :memo, size: "50x3" %>
-      </div>
+        <div class="field">
+          <%= t.label :name %>
+          <%= t.text_field :name %><br>
+          ↑ 入力必須<br>
+        </div>
+        <div class="field">
+          <%= t.label :memo %>
+          <%= t.text_area :memo, size: "50x3" %>
+        </div>
 
-      <%= t.hidden_field :status, value: "not_yet" %>
+        <%= t.hidden_field :status, value: "not_yet" %>
 
-      <div class="field">
-        <%= t.label :scheduled_complete_date %>
-        <%= t.date_field :scheduled_complete_date %><br>
-        ↑ 入力必須<br>
-      </div>
-      <div class="field">
-        <%= t.label :completed_date %>
-        <%= t.date_field :completed_date %><br>
-      </div>
+        <div class="field">
+          <%= t.label :scheduled_complete_date %>
+          <%= t.date_field :scheduled_complete_date %><br>
+          ↑ 入力必須<br>
+        </div>
+        <div class="field">
+          <%= t.label :completed_date %>
+          <%= t.date_field :completed_date %><br>
+        </div>
 
-      <div class="field">
-        <%= t.label :canceled_date %>
-        <%= t.date_field :canceled_date %><br>
-      </div>
+        <div class="field">
+          <%= t.label :canceled_date %>
+          <%= t.date_field :canceled_date %><br>
+        </div>
+      <% end %>
+
+      <hr>
+
     <% end %>
-
-    <hr>
-
-  <% end %>
+  </div>
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -64,7 +64,7 @@
     ↓進捗ステータスで「進捗中」、または「保留」を選んだ場合、「タスク名」、「完了予定日」は入力必須<br>
     ↓それ以外は、空欄可<br><br>
     <%= fields_for @task do |t| %>
-      <%= render 'devise/shared/error_messages', resource: @task %>
+      <%= render 'devise/shared/error_messages', resource: @task if @task.present? %>
 
       <div class="field">
         <%= t.label :name %>

--- a/app/views/leads/steps/_form.html.erb
+++ b/app/views/leads/steps/_form.html.erb
@@ -1,11 +1,3 @@
-<script type="text/javascript">
-$(function(){
-  $('#selector select[name="step[status]"]').on('change', function() {
-    if ($('select[name="step[status]"]').val()=='in_progress' || $('select[name="step[status]"]').val()=='inactive') $('#new_task').css('display','block');
-    else $('#new_task').css('display','none');
-  });
-});
-</script>
 <%= form_with(model: [lead, step], local: true) do |form| %>
   <%= render 'devise/shared/error_messages', resource: @step %>
 


### PR DESCRIPTION
## やったこと
issue#130に対する修正とjavascriptによる新規タスク作成フォームの制御
## やらないこと
無し。
## できるようになること(ユーザ目線)
エラー状態になることを回避すること。
新規進捗作成時に進捗ステータスとして「未」、「完了」、「テンプレート」を選んだ時、新規タスク作成フォームを表示しないこと。
## できなくなること(ユーザ目線)
無し。
## 動作確認
新規進捗作成と進捗編集時の動作確認。
## その他
leads/steps/_form.html.erbで、新規タスクフォーム表示状態から表示するために、進捗ステータスとして「進捗中」を選択した状態から始めました。
close #130
